### PR TITLE
Fixes #406 - Profile.special_privs can return None as one or more ele…

### DIFF
--- a/expo/gbe/models.py
+++ b/expo/gbe/models.py
@@ -134,7 +134,7 @@ class Profile(WorkerItem):
         from special_privileges import special_privileges
         privs = [ special_privileges.get(group, None) for group in 
                   self.privilege_groups]
-        return privs
+        return filter (lambda x: x is not None, privs)
 
     @property
     def privilege_groups(self):


### PR DESCRIPTION
…ments of the list. New code attempts to index into elements of this list, causing a fatal error.

This fix filters out elements which are None - quick workaround, need to understand this better.