### PR TITLE
Adding mailchimp integration. This is implemented as a templatetag. T…

### DIFF
--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -279,3 +279,8 @@ CMS_PERMISSION = True
 
 
 CMS_PLACEHOLDER_CONF = {}
+
+try: 
+   MC_API_KEY
+except:
+   MC_API_KEY = 'TEST'  # if not set, we won't try to hit mailchimp's API

--- a/expo/gbe/templates/gbe/incl_lp_left.tmpl
+++ b/expo/gbe/templates/gbe/incl_lp_left.tmpl
@@ -1,4 +1,5 @@
 <p>
+{% load gbe_tags %}
 {% if admin_message %}
     <font color=red>{{admin_message}}</font></br></br>
 {% elif user.is_authenticated %} 
@@ -21,4 +22,6 @@ Have you reserved your room at The Hyatt Regency Hotel yet? A single or double r
 This is your personal landing page, or it will be as soon as you  <a href='{% url 'gbe:register' %}'>create an account</a>. if you've already created an account, you just need to <a href = '{% url 'gbe:login' %}'>log in</a>.
 
 Once you're logged in, the middle column will show you your personal schedule of events you're signed up for: rehearsals, shows, classes you're teaching, volunteer shifts, etc. and the right-hand column is where you can see acts and classes you've submitted, submit your tech info for acts, and <a href='{% url 'gbe:volunteer_create' %}'>volunteer for The Expo</a>.
+<br>
+{% mailchimp %}
 {% endif %}

--- a/expo/gbe/templates/gbe/tag_templates/mailchimp.tmpl
+++ b/expo/gbe/templates/gbe/tag_templates/mailchimp.tmpl
@@ -1,0 +1,24 @@
+{% if have_mc %}
+<!-- Begin MailChimp Signup Form -->
+<link href="//cdn-images.mailchimp.com/embedcode/slim-081711.css" rel="stylesheet" type="text/css">
+<style type="text/css">
+       #mc_embed_signup{background:#fff; clear:left; font:14px Helvetica,Arial,sans-serif; }
+       /* Add your own MailChimp form style overrides in your site stylesheet or in this style block.
+          We recommend moving this block and the preceding CSS link to the HEAD of your HTML file. */
+</style>
+<div id="mc_embed_signup">
+<form action="//{{mc_api_url}}/subscribe/post?u={{mc_api_user}}&amp;id={{mc_api_id}}" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+    <div id="mc_embed_signup_scroll">
+    <label for="mce-EMAIL">Subscribe to our mailing list</label>
+    <input type="email" value="" name="EMAIL" class="email" id="mce-EMAIL" placeholder="email address" required>
+    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;">
+    <input type="text" name="b_{{mc_api_user}}_{{mc_api_id}}" tabindex="-1" value=""></div>
+    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+    </div>
+</form>
+</div>
+
+<!--End mc_embed_signup-->
+
+{% endif %}

--- a/expo/gbe/templatetags/gbe_tags.py
+++ b/expo/gbe/templatetags/gbe_tags.py
@@ -1,0 +1,14 @@
+from django import template
+from django.conf import settings
+
+register = template.Library()
+
+@register.inclusion_tag('gbe/tag_templates/mailchimp.tmpl')
+def mailchimp():
+    if settings.MC_API_KEY == 'TEST':
+        return {'have_mc': False}
+    return {'mc_api_url': settings.MC_API_URL, 
+            'mc_api_user': settings.MC_API_USER,
+            'mc_api_id': settings.MC_API_ID,
+            'have_mc': True,
+            }

--- a/expo/templates/base.tmpl
+++ b/expo/templates/base.tmpl
@@ -1,4 +1,4 @@
-{% load cms_tags staticfiles sekizai_tags menu_tags %}
+{% load cms_tags staticfiles sekizai_tags menu_tags gbe_tags %}
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
…wo things are necessary to make this work

1) in your local_settings, define MC_API_KEY, MC_API_URL, MC_API_USER, and MC_API_ID
2) load gbe_tags and use the tag {% mailchimp %} to include a standard mailchimp "super-slim subscribe" box

Note that if MC_API_KEY is not defined, django will assume that mailchimp is not set up, and simply not display the box.