### PR TITLE
GBE-630: Remove duplicate cases of worker in event details

### DIFF
--- a/expo/scheduler/models.py
+++ b/expo/scheduler/models.py
@@ -574,7 +574,7 @@ class EventItem (models.Model):
                  Q(role__in=['Teacher',
                              'Panelist',
                              'Moderator',
-                             'Staff Lead']))).distinct().order_by('role')
+                             'Staff Lead']))).distinct().order_by('role', '_item')
         except:
             people = Worker.objects.filter(
                 allocations__event__eventitem=self.eventitem_id,
@@ -582,7 +582,7 @@ class EventItem (models.Model):
                           'Panelist',
                           'Moderator',
                           'Staff Lead']
-            ).distinct().order_by('role')
+            ).distinct().order_by('role', '_item')
         return people
 
     def set_duration(self, duration):

--- a/expo/scheduler/templates/scheduler/event_detail.tmpl
+++ b/expo/scheduler/templates/scheduler/event_detail.tmpl
@@ -95,6 +95,7 @@
     {% elif eventitem.event.roles %}
     <div class="bio_block font_regular">
       {% for worker in eventitem.event.roles %}
+      {% ifchanged worker.workeritem %}
       <div class="bio_words">
 	{%if worker.role == "Staff Lead"%}
 	  <h2 class="bio_name subtitle">{{worker.role}} - {{worker.workeritem}}</h2>
@@ -109,6 +110,7 @@
           <img src="{{MEDIA_URL}}{{worker.workeritem.promo_small}}" class="sched_bio_image">
           </div>
         {% endif %}
+      {%endifchanged%}
       {% endfor %}
     </div>
     {% elif eventitem.event.bios %}

--- a/expo/tests/factories/scheduler_factories.py
+++ b/expo/tests/factories/scheduler_factories.py
@@ -5,7 +5,7 @@ import scheduler.models as sched
 from datetime import datetime
 from django.utils import timezone
 from tests.factories.gbe_factories import GenericEventFactory
-
+from gbe.duration import Duration
 
 class WorkerItemFactory(DjangoModelFactory):
     class Meta:
@@ -17,5 +17,6 @@ class SchedEventFactory(DjangoModelFactory):
         model = sched.Event
 
     eventitem = SubFactory(GenericEventFactory)
-    starttime = timezone.make_aware(datetime(2016, 02, 4),
+    starttime = timezone.make_aware(datetime(2015, 02, 4),
                                     timezone.get_current_timezone())
+    duration = Duration(hours=1)

--- a/expo/tests/functions/gbe_functions.py
+++ b/expo/tests/functions/gbe_functions.py
@@ -1,11 +1,13 @@
-import gbe.models as conf
+from  gbe.models import (
+    Profile,
+    User,
+)
 from django.contrib.auth.models import Group
 
-
 def user_for(user_or_profile):
-    if type(user_or_profile) == conf.Profile:
+    if type(user_or_profile) == Profile:
         user = user_or_profile.user_object
-    elif type(user_or_profile) == conf.User:
+    elif type(user_or_profile) == User:
         user = user_or_profile
     else:
         raise ValueError("login_as requires a Profile or User")
@@ -24,7 +26,7 @@ def grant_privilege(user_or_profile, privilege):
     '''
     user = user_for(user_or_profile)
     try:
-        g, nil = Group.objects.get_or_create(name=privilege)
+        g, _ = Group.objects.get_or_create(name=privilege)
     except:
         g = Group(name=privilege)
         g.save()


### PR DESCRIPTION
Closes #630.  

I would have rather done a distinct(‘role’, ‘_item’), but Django 1.6 with MySql doesn’t support this (it requires Postgres).

I tried a number of value() permutations but that flattens the query set into a dict, which breaks the expectations of the functional footprint.

This removes the duplicates from this specific thread.  The function is used other places, so one bonus is, it doesn’t change any other thread.