### PR TITLE
GBE 581:  Landing page schedule fixed for multiple conferences.

### DIFF
--- a/expo/gbe/templates/gbe/incl_schedule.tmpl
+++ b/expo/gbe/templates/gbe/incl_schedule.tmpl
@@ -9,6 +9,9 @@
   </h3>	
     {% for booking in profile.schedule %}
       {% if booking.eventitem.child.conference.status != "completed" %}
+        {% ifchanged booking.eventitem.child.conference %}
+	   <h4>{{booking.eventitem.child.conference}}</h4>
+        {% endifchanged%}
       <div class='event'>
         {{booking.starttime}}, 
         <a href="{% url 'scheduler:detail_view' booking.eventitem.eventitem_id%}">

--- a/expo/gbe/templates/gbe/incl_schedule.tmpl
+++ b/expo/gbe/templates/gbe/incl_schedule.tmpl
@@ -9,10 +9,12 @@
   </h3>	
     {% for booking in profile.schedule %}
       <div class='event'>
-        {{booking.starttime}} 
+      {% if booking.eventitem.child.conference.status != "completed" %}
+        {{booking.starttime}}, 
         <a href="{% url 'scheduler:detail_view' booking.eventitem.eventitem_id%}">
           {{ booking }}
 	</a> 
+      {%endif%}
       </div> <br>
     {% endfor %}
  

--- a/expo/gbe/templates/gbe/incl_schedule.tmpl
+++ b/expo/gbe/templates/gbe/incl_schedule.tmpl
@@ -8,15 +8,17 @@
        Schedule
   </h3>	
     {% for booking in profile.schedule %}
-      <div class='event'>
       {% if booking.eventitem.child.conference.status != "completed" %}
+      <div class='event'>
         {{booking.starttime}}, 
         <a href="{% url 'scheduler:detail_view' booking.eventitem.eventitem_id%}">
           {{ booking }}
 	</a> 
+      </div>
       {%endif%}
-      </div> <br>
+    {% empty %}
+      {{ profile.display_name }} is not scheduled for anything at this time.
     {% endfor %}
- 
+
 </div>
 

--- a/expo/gbe/templates/gbe/incl_schedule.tmpl
+++ b/expo/gbe/templates/gbe/incl_schedule.tmpl
@@ -7,8 +7,7 @@
      {% endif %} 
        Schedule
   </h3>	
-  {% if bookings %}
-    {% for booking in bookings %}
+    {% for booking in profile.schedule %}
       <div class='event'>
         {{booking.starttime}} 
         <a href="{% url 'scheduler:detail_view' booking.eventitem.eventitem_id%}">
@@ -16,9 +15,6 @@
 	</a> 
       </div> <br>
     {% endfor %}
-  {% else %}
-    {{ profile.display_name }} is not scheduled for anything at this time.
-      <br>
-  {% endif %}
+ 
 </div>
 

--- a/expo/gbe/templates/gbe/incl_schedule.tmpl
+++ b/expo/gbe/templates/gbe/incl_schedule.tmpl
@@ -7,7 +7,7 @@
      {% endif %} 
        Schedule
   </h3>	
-    {% for booking in profile.schedule %}
+    {% for booking in bookings %}
       {% with cs=booking.eventitem.child.conference.status %}
         {% if cs != "completed" and not historical or cs == "completed" and historical %}
           {% ifchanged booking.eventitem.child.conference %}

--- a/expo/gbe/templates/gbe/incl_schedule.tmpl
+++ b/expo/gbe/templates/gbe/incl_schedule.tmpl
@@ -8,17 +8,19 @@
        Schedule
   </h3>	
     {% for booking in profile.schedule %}
-      {% if booking.eventitem.child.conference.status != "completed" %}
-        {% ifchanged booking.eventitem.child.conference %}
-	   <h4>{{booking.eventitem.child.conference}}</h4>
-        {% endifchanged%}
-      <div class='event'>
-        {{booking.starttime}}, 
-        <a href="{% url 'scheduler:detail_view' booking.eventitem.eventitem_id%}">
-          {{ booking }}
-	</a> 
-      </div>
-      {%endif%}
+      {% with cs=booking.eventitem.child.conference.status %}
+        {% if cs != "completed" and not historical or cs == "completed" and historical %}
+          {% ifchanged booking.eventitem.child.conference %}
+	    <h4>{{booking.eventitem.child.conference}}</h4>
+          {% endifchanged%}
+          <div class='event'>
+            {{booking.starttime}}, 
+            <a href="{% url 'scheduler:detail_view' booking.eventitem.eventitem_id%}">
+            {{ booking }}
+	    </a> 
+          </div>
+        {%endif%}
+      {% endwith %}
     {% empty %}
       {{ profile.display_name }} is not scheduled for anything at this time.
     {% endfor %}

--- a/expo/gbe/templates/gbe/landing_page.tmpl
+++ b/expo/gbe/templates/gbe/landing_page.tmpl
@@ -9,7 +9,7 @@
      <div class="colmid">
 	  <div class="colleft">
 	       <div class="col1">
-                    {% if profile and bookings %}
+                    {% if profile and profile.schedule %}
                     <div class='landing_box'>
 			 {% include 'gbe/incl_schedule.tmpl' %}
 		    </div>

--- a/expo/gbe/templates/gbe/landing_page.tmpl
+++ b/expo/gbe/templates/gbe/landing_page.tmpl
@@ -9,7 +9,7 @@
      <div class="colmid">
 	  <div class="colleft">
 	       <div class="col1">
-                    {% if profile and profile.schedule %}
+                    {% if profile and bookings %}
                     <div class='landing_box'>
 			 {% include 'gbe/incl_schedule.tmpl' %}
 		    </div>

--- a/expo/gbe/views.py
+++ b/expo/gbe/views.py
@@ -201,7 +201,8 @@ def landing_page(request, profile_id=None, historical=False):
              'review_items': bids_to_review,
              'tickets': get_purchased_tickets(viewer_profile.user_object),
              'acceptance_states': acceptance_states,
-             'admin_message': admin_message
+             'admin_message': admin_message,
+             'bookings': viewer_profile.schedule
              })
     else:
         context = RequestContext(request,

--- a/expo/gbe/views.py
+++ b/expo/gbe/views.py
@@ -199,7 +199,6 @@ def landing_page(request, profile_id=None, historical=False):
              'volunteering': viewer_profile.get_volunteerbids(),
              'costumes': viewer_profile.get_costumebids(historical),
              'review_items': bids_to_review,
-             'bookings': viewer_profile.get_schedule(),
              'tickets': get_purchased_tickets(viewer_profile.user_object),
              'acceptance_states': acceptance_states,
              'admin_message': admin_message

--- a/expo/tests/gbe/test_landing_page.py
+++ b/expo/tests/gbe/test_landing_page.py
@@ -117,7 +117,6 @@ class TestIndex(TestCase):
         
         self.current_class_sched = Event(
             eventitem=self.current_class,
-            starttime=datetime(2016, 2, 5, 2, 0, 0, 0, pytz.utc),
             starttime=datetime(2016, 2, 5, 2, 30, 0, 0, pytz.utc),
             max_volunteer=10)
         self.current_class_sched.save()

--- a/expo/tests/gbe/test_landing_page.py
+++ b/expo/tests/gbe/test_landing_page.py
@@ -2,24 +2,32 @@ import gbe.models as conf
 import nose.tools as nt
 from unittest import TestCase
 from datetime import datetime
+import pytz
 from django.test.client import RequestFactory
 from django.core.urlresolvers import reverse
 from gbe.views import landing_page
 from tests.factories.gbe_factories import(
-    ConferenceFactory,
-    ProfileFactory,
     ActFactory,
     ClassFactory,
-    VendorFactory,
-    PersonaFactory,
+    ConferenceFactory,
     CostumeFactory,
-    VolunteerFactory
+    GenericEventFactory,
+    PersonaFactory,
+    ProfileFactory,
+    VendorFactory,
+    VolunteerFactory,
+)
+from scheduler.models import (
+    Event,
+    ResourceAllocation,
+    Worker
 )
 
 
 class TestIndex(TestCase):
     '''Tests for index view'''
     def setUp(self):
+        # Conference Setup
         self.factory = RequestFactory()
         self.current_conf = ConferenceFactory.create(accepting_bids=True)
         self.current_conf.status = 'upcoming'
@@ -28,9 +36,12 @@ class TestIndex(TestCase):
         self.previous_conf.status = 'completed'
         self.previous_conf.save()
 
+        # User/Human setup
         self.profile = ProfileFactory.create()
         self.performer = PersonaFactory.create(performer_profile=self.profile,
                                                contact=self.profile)
+        
+        #Bid types previous and current
         self.current_act = ActFactory.create(performer=self.performer,
                                              submitted=True)
         self.current_act.conference = self.current_conf
@@ -42,12 +53,14 @@ class TestIndex(TestCase):
         self.previous_act.conference = self.previous_conf
         self.previous_act.save()
         self.current_class = ClassFactory.create(teacher=self.performer,
-                                                 submitted=True)
+                                                 submitted=True,
+                                                 accepted=3)
         self.current_class.title = "Current Class"
         self.current_class.conference = self.current_conf
         self.current_class.save()
         self.previous_class = ClassFactory.create(teacher=self.performer,
-                                                  submitted=True)
+                                                  submitted=True,
+                                                  accepted=3)
         self.previous_class.conference = self.previous_conf
         self.previous_class.title = 'Previous Class'
         self.previous_class.save()
@@ -79,6 +92,77 @@ class TestIndex(TestCase):
                                                           submitted=True)
         self.previous_volunteer.conference = self.previous_conf
         self.previous_volunteer.save()
+        
+        # Event assignments, previous and current
+        current_opportunity = GenericEventFactory.create(
+            conference=self.current_conf,
+            title="Current Volunteering",
+            type='Volunteer')
+        current_opportunity.save()
+        previous_opportunity = GenericEventFactory.create(
+            title="Previous Volunteering",
+            conference=self.previous_conf)
+        previous_opportunity.save()
+
+        self.current_sched = Event(
+            eventitem=current_opportunity,
+            starttime=datetime(2016, 2, 5, 12, 30, 0, 0, tzinfo=pytz.utc),
+            max_volunteer=10)
+        self.current_sched.save()
+        self.previous_sched = Event(
+            eventitem=previous_opportunity,
+            starttime=datetime(2015, 2, 25, 12, 30, 0, 0, pytz.utc),
+            max_volunteer=10)
+        self.previous_sched.save()
+        
+        self.current_class_sched = Event(
+            eventitem=self.current_class,
+            starttime=datetime(2016, 2, 5, 2, 0, 0, 0, pytz.utc),
+            max_volunteer=10)
+        self.current_class_sched.save()
+        self.previous_class_sched = Event(
+            eventitem=self.previous_class,
+            starttime=datetime(2015, 2, 25, 2, 0, 0, 0, pytz.utc),
+            max_volunteer=10)
+        self.previous_class_sched.save()
+        
+        worker = Worker(_item=self.profile, role='Volunteer')
+        worker.save()
+        for schedule_item in [self.current_sched,
+                              self.previous_sched]:
+            volunteer_assignment = ResourceAllocation(
+                event=schedule_item,
+                resource=worker
+                )
+            volunteer_assignment.save()
+
+        persona_worker = Worker(_item=self.performer, role='Teacher')
+        persona_worker.save()
+        for schedule_item in [self.current_class_sched,
+                              self.previous_class_sched]:
+            volunteer_assignment = ResourceAllocation(
+                event=schedule_item,
+                resource=worker
+                )
+            volunteer_assignment.save()
+
+
+    def is_event_present(self, event, content):
+        ''' test all parts of the event being on the landing page schedule'''
+        print(content)
+        print ("event:"+unicode(event))
+        print("time:"+event.start_time.strftime(
+                    "%b. %-d, %Y, %-I:%M") )
+        print("link:"+reverse('detail_view',
+                        urlconf="scheduler.urls",
+                        args=[event.eventitem.eventitem_id]))
+
+        return (unicode(event) in content and
+                event.start_time.strftime(
+                    "%b. %-d, %Y, %-I:%M") in content and
+                reverse('detail_view',
+                        urlconf="scheduler.urls",
+                        args=[event.eventitem.eventitem_id]) in content)
 
     def test_landing_page_path(self):
         '''Basic test of landing_page view
@@ -107,6 +191,10 @@ class TestIndex(TestCase):
                     args=[self.current_volunteer.id]) in content)
         nt.assert_true(does_not_show_previous and
                        shows_all_current)
+        nt.assert_true(self.is_event_present(self.current_sched, content))
+        nt.assert_false(self.is_event_present(self.previous_sched, content))
+        nt.assert_true(self.is_event_present(self.current_class_sched, content))
+        nt.assert_false(self.is_event_present(self.previous_class_sched, content))
 
     def test_historical_view(self):
         request = self.factory.get('/')
@@ -128,3 +216,7 @@ class TestIndex(TestCase):
             self.current_costume.title not in content)
         nt.assert_true(shows_all_previous and
                        does_not_show_current)
+        nt.assert_false(self.is_event_present(self.current_sched, content))
+        nt.assert_true(self.is_event_present(self.previous_sched, content))
+        nt.assert_false(self.is_event_present(self.current_class_sched, content))
+        nt.assert_true(self.is_event_present(self.previous_class_sched, content))

--- a/expo/tests/gbe/test_landing_page.py
+++ b/expo/tests/gbe/test_landing_page.py
@@ -118,11 +118,12 @@ class TestIndex(TestCase):
         self.current_class_sched = Event(
             eventitem=self.current_class,
             starttime=datetime(2016, 2, 5, 2, 0, 0, 0, pytz.utc),
+            starttime=datetime(2016, 2, 5, 2, 30, 0, 0, pytz.utc),
             max_volunteer=10)
         self.current_class_sched.save()
         self.previous_class_sched = Event(
             eventitem=self.previous_class,
-            starttime=datetime(2015, 2, 25, 2, 0, 0, 0, pytz.utc),
+            starttime=datetime(2015, 2, 25, 2, 30, 0, 0, pytz.utc),
             max_volunteer=10)
         self.previous_class_sched.save()
         
@@ -149,14 +150,6 @@ class TestIndex(TestCase):
 
     def is_event_present(self, event, content):
         ''' test all parts of the event being on the landing page schedule'''
-        print(content)
-        print ("event:"+unicode(event))
-        print("time:"+event.start_time.strftime(
-                    "%b. %-d, %Y, %-I:%M") )
-        print("link:"+reverse('detail_view',
-                        urlconf="scheduler.urls",
-                        args=[event.eventitem.eventitem_id]))
-
         return (unicode(event) in content and
                 event.start_time.strftime(
                     "%b. %-d, %Y, %-I:%M") in content and

--- a/expo/tests/gbe/test_landing_page.py
+++ b/expo/tests/gbe/test_landing_page.py
@@ -1,7 +1,9 @@
 import gbe.models as conf
 import nose.tools as nt
 from unittest import TestCase
+from datetime import datetime
 from django.test.client import RequestFactory
+from django.core.urlresolvers import reverse
 from gbe.views import landing_page
 from tests.factories.gbe_factories import(
     ConferenceFactory,
@@ -11,6 +13,7 @@ from tests.factories.gbe_factories import(
     VendorFactory,
     PersonaFactory,
     CostumeFactory,
+    VolunteerFactory
 )
 
 
@@ -68,6 +71,14 @@ class TestIndex(TestCase):
         self.previous_costume.conference = self.previous_conf
         self.previous_costume.title = 'Previous Costume'
         self.previous_costume.save()
+        self.current_volunteer = VolunteerFactory.create(profile=self.profile,
+                                                         submitted=True)
+        self.current_volunteer.conference = self.current_conf
+        self.current_volunteer.save()
+        self.previous_volunteer = VolunteerFactory.create(profile=self.profile,
+                                                          submitted=True)
+        self.previous_volunteer.conference = self.previous_conf
+        self.previous_volunteer.save()
 
     def test_landing_page_path(self):
         '''Basic test of landing_page view
@@ -82,12 +93,18 @@ class TestIndex(TestCase):
             self.previous_act.title not in content and
             self.previous_class.title not in content and
             self.previous_vendor.title not in content and
-            self.previous_costume.title not in content)
+            self.previous_costume.title not in content and
+            reverse('volunteer_view',
+                    urlconf='gbe.urls',
+                    args=[self.previous_volunteer.id]) not in content)
         shows_all_current = (
             self.current_act.title in content and
             self.current_class.title in content and
             self.current_vendor.title in content and
-            self.current_costume.title in content)
+            self.current_costume.title in content and
+            reverse('volunteer_view',
+                    urlconf='gbe.urls',
+                    args=[self.current_volunteer.id]) in content)
         nt.assert_true(does_not_show_previous and
                        shows_all_current)
 
@@ -99,13 +116,15 @@ class TestIndex(TestCase):
         response = landing_page(request)
         content = response.content
         self.assertEqual(response.status_code, 200)
-        shows_all_previous = (self.previous_act.title in content and
-                              self.previous_class.title in content and
-                              self.previous_vendor.title in content and
-                              self.previous_costume.title in content)
-        does_not_show_current = (self.current_act.title not in content and
-                                 self.current_class.title not in content and
-                                 self.current_vendor.title not in content and
-                                 self.current_costume.title not in content)
+        shows_all_previous = (
+            self.previous_act.title in content and
+            self.previous_class.title in content and
+            self.previous_vendor.title in content and
+            self.previous_costume.title in content in content)
+        does_not_show_current = (
+            self.current_act.title not in content and
+            self.current_class.title not in content and
+            self.current_vendor.title not in content and
+            self.current_costume.title not in content)
         nt.assert_true(shows_all_previous and
                        does_not_show_current)


### PR DESCRIPTION
Closes #581
———————

Now testing is complete - it tests:
- that a current scheduled class is shown in regular mode
- that a past class is shown in historic mode
- that a current scheduled volunteer opportunity is shown in regular
mode
- that a past scheduled volunteer opportunity is shown in historic mode

And also vice, versa that things that are in regular mode are NOT in
historic mode and things in historic mode are NOT in regular mode.

Of note- getting the timestamps right is super nitpicky and I couldn’t
emulate it perfectly, but this should demonstrate that the timestamp is
not completely wrong.

Also - I chose not to test act assignment - it is one more logical
thread, but it was just one too many, and is not part of the code
changes that I affected in the update.

—————————

Functionality description:

1: visible on the landing page to any user:

http://localhost:8282/gbe

provided that the user has a role (resource allocation) in a scheduled event that is in an upcoming or current conference.

If there is more than one active conference (you can test this with our test data by setting “GBE 9” to be current - then each conference is shown ordered from past to future.

The conference’s name is now in the schedule to show which conference is which.

———

2 - if you select “View older bids” then the schedule is flipped and shows only past conferences.

——

A quick way to test this with relatively recent live data would be to look for users who have been booked into acts in this year’s shows.  Then they will have at least 1 schedule item (the show) and possibly 1 rehearsal if they have done their signup.