### PR TITLE
GBE-654: Comments on review volunteer list page not filtered per conference

### DIFF
--- a/expo/gbe/models.py
+++ b/expo/gbe/models.py
@@ -309,7 +309,7 @@ class Profile(WorkerItem):
         Otherwise, it's the same logic as schedule() below.
         '''
         events = self.schedule
-        if conference:  
+        if conference:
             conf_events = filter(
                 lambda x: x.eventitem.get_conference() == conference, events)
         else:

--- a/expo/gbe/models.py
+++ b/expo/gbe/models.py
@@ -303,17 +303,18 @@ class Profile(WorkerItem):
                  for act in acts if act.accepted == 3 and act.is_current]
         return sum([list(s) for s in shows], [])
 
-    def get_schedule(self):
+    def get_schedule(self, conference=None):
         '''
-        Gets all of a person's schedule.  Every way the actual human could
-        be committed:
-        - via profile
-        - via performer(s)
-        - via performing in acts
-        Returns schedule as a list of Scheduler.Events
-        NOTE:  Things that haven't been booked with start times won't be here.
+        Gets all schedule items for a conference, if a conference is provided
+        Otherwise, it's the same logic as schedule() below.
         '''
-        return self.schedule
+        events = self.schedule
+        if conference:  
+            conf_events = filter(
+                lambda x: x.eventitem.get_conference() == conference, events)
+        else:
+            conf_events = events
+        return conf_events
 
     @property
     def schedule(self):
@@ -326,15 +327,15 @@ class Profile(WorkerItem):
         Returns schedule as a list of Scheduler.Events
         NOTE:  Things that haven't been booked with start times won't be here.
         '''
-        from scheduler.models import Event
+        from scheduler.models import Event as sEvent
         acts = self.get_acts()
-        events = sum([list(Event.objects.filter(
+        events = sum([list(sEvent.objects.filter(
             resources_allocated__resource__actresource___item=act))
                       for act in acts if act.accepted == 3], [])
         for performer in self.get_performers():
-            events += [e for e in Event.objects.filter(
+            events += [e for e in sEvent.objects.filter(
                 resources_allocated__resource__worker___item=performer)]
-        events += [e for e in Event.objects.filter(
+        events += [e for e in sEvent.objects.filter(
             resources_allocated__resource__worker___item=self)]
         return sorted(set(events), key=lambda event: event.start_time)
 
@@ -1518,11 +1519,17 @@ class Volunteer(Biddable):
             unavailability_string += unicode(window) + ', \n'
 
         commitments = ''
-        time_format = set_time_format(days=2)
-        for event in self.profile.get_schedule():
-            start_time = event.starttime.strftime(time_format)
-            commitment_string = "%s - %s, \n " % (str(event),
-                                                  start_time)
+        start_time_format = set_time_format(days=2)
+        end_time_format = set_time_format()
+
+        for event in self.profile.get_schedule(self.conference):
+            start_time = event.start_time.strftime(start_time_format)
+            end_time = event.end_time.strftime(end_time_format)
+
+            commitment_string = "%s - %s to %s, \n " % (
+                str(event),
+                start_time,
+                end_time)
             commitments += commitment_string
         format_string = "Availability: %s\n Conflicts: %s\n Commitments: %s"
         scheduling = format_string % (availability_string,

--- a/expo/gbe/models.py
+++ b/expo/gbe/models.py
@@ -1519,12 +1519,10 @@ class Volunteer(Biddable):
             unavailability_string += unicode(window) + ', \n'
 
         commitments = ''
-        start_time_format = set_time_format(days=2)
-        end_time_format = set_time_format()
 
         for event in self.profile.get_schedule(self.conference):
-            start_time = event.start_time.strftime(start_time_format)
-            end_time = event.end_time.strftime(end_time_format)
+            start_time = event.start_time.strftime("%a, %b %d, %-I:%M %p")
+            end_time = event.end_time.strftime("%-I:%M %p")
 
             commitment_string = "%s - %s to %s, \n " % (
                 str(event),

--- a/expo/tests/gbe/test_review_volunteer_list.py
+++ b/expo/tests/gbe/test_review_volunteer_list.py
@@ -14,6 +14,7 @@ from tests.factories.gbe_factories import (
     UserFactory,
     VolunteerFactory,
     VolunteerWindowFactory)
+from tests.factories.scheduler_factories import ResourceAllocationFactory
 from tests.functions.gbe_functions import login_as
 from django.core.exceptions import PermissionDenied
 from gbe.models import ProfilePreferences
@@ -22,7 +23,6 @@ from datetime import datetime, date, time
 import pytz
 from scheduler.models import (
     Worker,
-    ResourceAllocation,
     EventContainer
 )
 
@@ -149,11 +149,10 @@ class TestReviewVolunteerList(TestCase):
         booked_sched.save()
         worker = Worker(_item=self.volunteer.profile, role='Volunteer')
         worker.save()
-        volunteer_assignment = ResourceAllocation(
+        volunteer_assignment = ResourceAllocationFactory.create(
             event=booked_sched,
             resource=worker
         )
-        volunteer_assignment.save()
 
         request = self.factory.get('volunteer/review/?conf_slug=%s' %
                                    self.volunteer.conference.conference_slug)
@@ -199,11 +198,10 @@ class TestReviewVolunteerList(TestCase):
         booked_sched.save()
         worker = Worker(_item=self.volunteer.profile, role='Volunteer')
         worker.save()
-        volunteer_assignment = ResourceAllocation(
+        volunteer_assignment = ResourceAllocationFactory.create(
             event=booked_sched,
             resource=worker
         )
-        volunteer_assignment.save()
 
         request = self.factory.get('volunteer/review/?conf_slug=%s' %
                                    self.volunteer.conference.conference_slug)

--- a/expo/tests/gbe/test_review_volunteer_list.py
+++ b/expo/tests/gbe/test_review_volunteer_list.py
@@ -7,6 +7,8 @@ from django.test import Client
 from gbe.views import review_volunteer_list
 from django.contrib.auth.models import Group
 from tests.factories.gbe_factories import (
+    ConferenceFactory,
+    GenericEventFactory,
     PersonaFactory,
     ProfileFactory,
     UserFactory,
@@ -15,6 +17,15 @@ from tests.factories.gbe_factories import (
 from tests.functions.gbe_functions import login_as
 from django.core.exceptions import PermissionDenied
 from gbe.models import ProfilePreferences
+from scheduler.models import Event as sEvent
+from datetime import datetime, date, time
+import pytz
+from scheduler.models import (
+    Worker,
+    ResourceAllocation,
+    EventContainer
+)
+
 
 class TestReviewVolunteerList(TestCase):
     '''Tests for review_volunteer_list view'''
@@ -44,7 +55,6 @@ class TestReviewVolunteerList(TestCase):
         self.prefs.show_hotel_infobox = True
         self.prefs.save()
 
-
     def test_review_volunteer_all_well(self):
         '''default conference selected, make sure it returns the right page'''
         request = self.factory.get('volunteer/review/')
@@ -52,7 +62,7 @@ class TestReviewVolunteerList(TestCase):
         request.session = {'cms_admin_site': 1}
         login_as(request.user, self)
         response = review_volunteer_list(request)
-        
+
         nt.assert_equal(response.status_code, 200)
         nt.assert_true('Bid Information' in response.content)
 
@@ -80,7 +90,7 @@ class TestReviewVolunteerList(TestCase):
         request.session = {'cms_admin_site': 1}
         login_as(request.user, self)
         response = review_volunteer_list(request)
-        
+
         nt.assert_equal(response.status_code, 200)
         nt.assert_true('Bid Information' in response.content)
         nt.assert_true(str(self.volunteer.number_shifts) in response.content)
@@ -108,7 +118,7 @@ class TestReviewVolunteerList(TestCase):
         request.session = {'cms_admin_site': 1}
         login_as(request.user, self)
         response = review_volunteer_list(request)
-        
+
         nt.assert_equal(response.status_code, 200)
         nt.assert_true('Bid Information' in response.content)
         nt.assert_true(str(self.volunteer.number_shifts) in response.content)
@@ -123,6 +133,90 @@ class TestReviewVolunteerList(TestCase):
         nt.assert_true("Review" in response.content)
         nt.assert_true("Assign" in response.content)
         nt.assert_true("Edit" in response.content)
+
+    def test_review_volunteer_has_commitments(self):
+        ''' when a volunteer is already booked somewhere, it should show up'''
+
+        current_opportunity = GenericEventFactory.create(
+            conference=self.volunteer.conference,
+            volunteer_category='VA1',
+            type='Volunteer')
+        current_opportunity.save()
+        booked_sched = sEvent(
+            eventitem=current_opportunity,
+            starttime=datetime(2016, 2, 6, 9, 0, 0, 0, pytz.utc),
+            max_volunteer=1)
+        booked_sched.save()
+        worker = Worker(_item=self.volunteer.profile, role='Volunteer')
+        worker.save()
+        volunteer_assignment = ResourceAllocation(
+            event=booked_sched,
+            resource=worker
+        )
+        volunteer_assignment.save()
+
+        request = self.factory.get('volunteer/review/?conf_slug=%s' %
+                                   self.volunteer.conference.conference_slug)
+        request.user = self.privileged_user
+        request.session = {'cms_admin_site': 1}
+        login_as(request.user, self)
+        response = review_volunteer_list(request)
+        print(response)
+
+        nt.assert_equal(response.status_code, 200)
+        nt.assert_true('Bid Information' in response.content)
+        nt.assert_equal(
+            response.content.count(str(current_opportunity)),
+            1,
+            msg="The commitment %s is not showing up" % (
+                str(current_opportunity)))
+        nt.assert_in(
+            booked_sched.start_time.strftime("%a, %b %d, %-I:%M %p"),
+            response.content,
+            msg="start time for commitment (%s) didn't show up" % (
+                booked_sched.start_time.strftime("%a, %b %d, %-I:%M %p")))
+        nt.assert_in(
+            booked_sched.end_time.strftime("%-I:%M %p"),
+            response.content,
+            msg="end time for commitment (%s) didn't show up" % (
+                booked_sched.end_time.strftime("%-I:%M %p")))
+
+    def test_review_volunteer_has_old_commitments(self):
+        ''' when a volunteer is booked in old conference, it should not show'''
+        past_conference = ConferenceFactory.create(
+            accepting_bids=False,
+            status='completed'
+            )
+        past_opportunity = GenericEventFactory.create(
+            conference=past_conference,
+            volunteer_category='VA1',
+            type='Volunteer')
+        past_opportunity.save()
+        booked_sched = sEvent(
+            eventitem=past_opportunity,
+            starttime=datetime(2016, 2, 6, 9, 0, 0, 0, pytz.utc),
+            max_volunteer=1)
+        booked_sched.save()
+        worker = Worker(_item=self.volunteer.profile, role='Volunteer')
+        worker.save()
+        volunteer_assignment = ResourceAllocation(
+            event=booked_sched,
+            resource=worker
+        )
+        volunteer_assignment.save()
+
+        request = self.factory.get('volunteer/review/?conf_slug=%s' %
+                                   self.volunteer.conference.conference_slug)
+        request.user = self.privileged_user
+        request.session = {'cms_admin_site': 1}
+        login_as(request.user, self)
+        response = review_volunteer_list(request)
+
+        nt.assert_equal(response.status_code, 200)
+        nt.assert_true('Bid Information' in response.content)
+        nt.assert_false(str(past_opportunity) in response.content,
+                        msg="The commitment %s is showing up" % (
+                            str(past_opportunity)))
 
     @nt.raises(PermissionDenied)
     def test_review_volunteer_bad_user(self):


### PR DESCRIPTION
Closes #654
- fixes a problem on 
http://localhost:8282/volunteer/reviewlist

Where a volunteer with bookings from 2015 has their booking show up.  Because the booking also don’t show date, it looks like they are current to this year, making the visual really confusing.

The fix is to screen out all commitments that are NOT a part of this conference, and also to show the date, the way we do with volunteer windows, so it is clearer what the commitment is.