### PR TITLE
GBE-656: Submenus not working in Django-CMS 

### DIFF
--- a/expo/gbe/static/styles/gbe_bootstrap.min.css
+++ b/expo/gbe/static/styles/gbe_bootstrap.min.css
@@ -3251,6 +3251,16 @@ input[type="submit"].btn-block,input[type="reset"].btn-block,input[type="button"
 	background-clip:padding-box
 }
 
+.dropdown-menu > li.dropdown > ul.dropdown-menu{
+	left: 98%;
+	top: 0px
+}
+
+.navbar > li.dropdown > .dropdown-menu{
+	top:100%;
+	left:0;
+}
+
 .dropdown-menu.pull-right{
 	right:0;
 	left:auto

--- a/expo/templates/base.tmpl
+++ b/expo/templates/base.tmpl
@@ -57,7 +57,7 @@
             </div>
             <div class="navbar-collapse collapse">
               <ul class="nav navbar-nav">
-                {% show_menu 0 1 100 100 "menu.tmpl" %}
+                {% show_menu 0 100 100 100 "menu.tmpl" %}
               </ul>
             </div>
       </div>
@@ -72,3 +72,13 @@
 
   </body>
 </html>
+
+<script>
+$(document).ready(function(){
+  $('.dropdown a.dropdown-toggle').on("click", function(e){
+    $(this).next('ul').toggle();
+    e.stopPropagation();
+    e.preventDefault();
+  });
+});
+</script>

--- a/expo/templates/base.tmpl
+++ b/expo/templates/base.tmpl
@@ -75,11 +75,21 @@
 
 <script>
 $(document).ready(function(){
-  $('.dropdown a.dropdown-toggle').on("click", function(e){
-    $(this).next('ul').toggle();
-    e.stopPropagation();
-    e.preventDefault();
-  });
+	$(".dropdown-menu > li > a.trigger").on("click",function(e){
+		var current=$(this).next();
+		var grandparent=$(this).parent().parent();
+		if($(this).hasClass('left-caret')||$(this).hasClass('right-caret'))
+			$(this).toggleClass('right-caret left-caret');
+		grandparent.find('.left-caret').not(this).toggleClass('right-caret left-caret');
+		grandparent.find(".sub-menu:visible").not(current).hide();
+		current.toggle();
+		e.stopPropagation();
+	});
+	$(".dropdown-menu > li > a:not(.trigger)").on("click",function(){
+		var root=$(this).closest('.dropdown');
+		root.find('.left-caret').toggleClass('right-caret left-caret');
+		root.find('.sub-menu:visible').hide();
+	});
 });
 
 $.extend( true, $.fn.dataTable.defaults, {

--- a/expo/templates/menu.tmpl
+++ b/expo/templates/menu.tmpl
@@ -3,7 +3,7 @@
 {% for child in children %}
 
 
-<li class="{% if child.ancestor %}ancestor{% endif %}{% if child.selected %}active{% endif %}{% if child.children %}dropdown{% endif %}">
+<li class="{% if child.ancestor %}ancestor{% endif %} {% if child.selected %}active{% endif %} {% if child.children %}dropdown{% endif %}">
     {% if child.children %}<a class="dropdown-toggle" data-toggle="dropdown" href="#">
       {{ child.get_menu_title }} <span class="caret"></span>
     </a>

--- a/expo/templates/menu.tmpl
+++ b/expo/templates/menu.tmpl
@@ -4,7 +4,7 @@
 
 
 <li class="{% if child.ancestor %}ancestor{% endif %} {% if child.selected %}active{% endif %} {% if child.children %}dropdown{% endif %}">
-    {% if child.children %}<a class="dropdown-toggle" data-toggle="dropdown" href="#">
+    {% if child.children %}<a class="dropdown-toggle trigger" data-toggle="dropdown" href="#">
       {{ child.get_menu_title }} <span class="caret"></span>
     </a>
     <ul class="dropdown-menu">


### PR DESCRIPTION
- submenus appear
- positioning is not horrific
- fix an existing bug in menu.tmpl - no spaces in classes mean one big
class.

To Test:
- pull the latest data from GBE Live
- make sure you have a clean browser refresh for CSS and JS
- go to Shows & Events —> All Shows

NOW - you will see that there are 4 shows, each with a working page.

The sub menu is positioned to the right of the parent menu item and the rest of the menus in the system appear in a reasonable position relative to their parents.

Prior to this fix, this did not work - submenus didn’t appear.

Closes #656 