### PR TITLE
GBE 608: Improving volunteer management

### DIFF
--- a/expo/gbe/forms.py
+++ b/expo/gbe/forms.py
@@ -452,7 +452,6 @@ class VolunteerBidForm(forms.ModelForm):
         self.fields['available_windows'].queryset = available_windows
         self.fields['unavailable_windows'].queryset = unavailable_windows
 
-
     class Meta:
         model = Volunteer
         fields = ['number_shifts',

--- a/expo/gbe/forms.py
+++ b/expo/gbe/forms.py
@@ -474,23 +474,30 @@ class VolunteerBidForm(forms.ModelForm):
 
 
 class VolunteerOpportunityForm(forms.ModelForm):
-    day = forms.ChoiceField(choices=['No Days Specified'])
+    day = forms.ChoiceField(
+        choices=['No Days Specified'],
+        error_messages={'required': 'required'})
     time = forms.ChoiceField(choices=conference_times)
     opp_event_id = forms.IntegerField(widget=forms.HiddenInput(),
                                       required=False)
     opp_sched_id = forms.IntegerField(widget=forms.HiddenInput(),
                                       required=False)
-    num_volunteers = forms.IntegerField()
+    num_volunteers = forms.IntegerField(
+        error_messages={'required': 'required'})
     volunteer_category = forms.ChoiceField(choices=volunteer_interests_options,
                                            required=False)
-    location = forms.ModelChoiceField(queryset=Room.objects.all())
-    duration = DurationFormField()
+    location = forms.ModelChoiceField(
+        queryset=Room.objects.all(),
+        error_messages={'required': 'required'})
+    duration = DurationFormField(
+        error_messages={'null': 'required'})
 
     def __init__(self, *args, **kwargs):
         conference = kwargs.pop('conference')
         super(VolunteerOpportunityForm, self).__init__(*args, **kwargs)
         self.fields['day'] = forms.ModelChoiceField(
-            queryset=conference.conferenceday_set.all())
+            queryset=conference.conferenceday_set.all(),
+            error_messages={'required': 'required'})
 
     class Meta:
         model = GenericEvent

--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -787,3 +787,13 @@ td.form_field > ul > li
   font-size: 20px;
   color: black;
 }
+
+input#id_num_volunteers, input#id_new_opp-num_volunteers
+{
+  width: 40px
+}
+
+input#id_duration, input#id_new_opp-duration
+{
+  width: 70px
+}

--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -797,3 +797,14 @@ input#id_duration, input#id_new_opp-duration
 {
   width: 70px
 }
+
+span.opps-errors > ul > li
+{
+  list-style-type: none;
+  color: red;
+}
+
+span.opps-errors > ul 
+{
+  padding: 0px;
+}

--- a/expo/scheduler/templates/scheduler/manage_opps.tmpl
+++ b/expo/scheduler/templates/scheduler/manage_opps.tmpl
@@ -8,6 +8,7 @@ included in event edit flow. If there is an actionform, show it
 
 <div class=side_box>
   <h2>Volunteer Management</h2>
+  <p># = Number of Volunteers Needed</p>
   <table class="event_opps">
     <tr> 
     {% for header in actionheaders %}
@@ -23,21 +24,21 @@ included in event edit flow. If there is an actionform, show it
 	{% for field in form.visible_fields %}
 	  <td>
           {% if field.errors %}
-            <font color="red">!</font>&nbsp;&nbsp;
           {% endif %}
             {{ field }}
           {% if field.errors %}
-            </br>
-            <font color="red">{{ field.errors }}</font>
+	    <span class="opps-errors">
+              {{ field.errors }}
+	    </span>
           {% endif %}
 	  </td> 	{% endfor %}	    	
 	{% for field in form.hidden_fields %}
 	  {{field}}
 	{% endfor %}
-	  <td>  <input type = "submit" name="edit" value="Edit Opportunity"><br>
-	  	<input type = "submit" name="duplicate" value="Duplicate Opportunity"><br>
+	  <td>  <input type = "submit" name="edit" value="Edit"><br>
+	  	<input type = "submit" name="duplicate" value="Copy"><br>
 	        <input type = "submit" name="delete" value="Delete"></br>
-	        <input type = "submit" name="allocate" value = "Allocate Workers">
+	        <input type = "submit" name="allocate" value = "Staff">
 	  </td>
       </form>	      
     </tr>
@@ -49,16 +50,16 @@ included in event edit flow. If there is an actionform, show it
 	{% for field in createform.visible_fields %}
 	  <td>
           {% if field.errors %}
-            <font color="red">!</font>&nbsp;&nbsp;
           {% endif %}
             {{ field }}
           {% if field.errors %}
-            </br>
-            <font color="red">{{ field.errors }}</font>
+	    <span class="opps-errors">
+              {{ field.errors }}
+	    </span>
           {% endif %}
 	  </td>
 	{% endfor %}	    		      
- 	<td>  <input type = "submit" name="create" value="Create Opportunity"></td>
+ 	<td>  <input type = "submit" name="create" value="Create"></td>
 
       </form>	      
     </tr>

--- a/expo/scheduler/views.py
+++ b/expo/scheduler/views.py
@@ -370,7 +370,7 @@ def get_manage_opportunity_forms(item, initial, errorcontext=None):
 
     actionheaders = ['Title',
                      'Volunteer Type',
-                     'Volunteers Needed',
+                     '#',
                      'Duration',
                      'Day',
                      'Time',

--- a/expo/scheduler/views.py
+++ b/expo/scheduler/views.py
@@ -973,7 +973,6 @@ def calendar_view(request=None,
     else:
         conf = get_current_conference()
 
-
     cal_times = cal_times_for_conf(conf, day)
 
     if event_type == 'All':


### PR DESCRIPTION
closes #608

(this time, for real)
- CSS reformatting to reduce the size of # of volunteers needed and duration
- less wordy buttons to make action column smaller
- changed header from “Volunteers Needed” to “#” to save space
- streamlined error messaging to fit a smaller row-based context.