### PR TITLE
GBE-736: Remove "time bomb" from test_reports.py

### DIFF
--- a/expo/tests/gbe/test_reports.py
+++ b/expo/tests/gbe/test_reports.py
@@ -176,9 +176,6 @@ class TestReports(TestCase):
     def test_staff_area_path(self):
         '''staff_area view should load
         '''
-        nt.assert_true(date.today() < date(2016, 3, 1),
-                       msg="Time to fix test_staff_area!")
-
         profile = ProfileFactory()
         show = ShowFactory()
         context = VolunteerContext(event=show)


### PR DESCRIPTION
@bethlakshmi if you'd rather add this to GBE-732, that's fine with me, just leave a comment and close this PR. Up to you. 