### PR TITLE
GBE-744: Install ipython shell, django will select it by default

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -45,3 +45,4 @@ six==1.9.0
 coverage
 django-compat
 django-hijack
+ipython==3.0


### PR DESCRIPTION
Installing ipython on the vagrant box causes manage.py to select it by default
Locked us to version 3.0 since current versions produce much deprecation warnings. Can unlock this when we get the upgrade going. 