### PR TITLE
GBE-774 scheduler.event_list coverage

### DIFF
--- a/expo/tests/scheduler/test_event_list.py
+++ b/expo/tests/scheduler/test_event_list.py
@@ -1,0 +1,44 @@
+from django.core.urlresolvers import reverse
+import nose.tools as nt
+from unittest import TestCase
+from django.test import Client
+from tests.factories.gbe_factories import (
+    ProfileFactory,
+    ShowFactory,
+)
+from tests.functions.gbe_functions import (
+    current_conference,
+    grant_privilege,
+    login_as,
+)
+
+class TestEventList(TestCase):
+    view_name = 'event_schedule'
+
+    def setUp(self):
+        self.client = Client()
+        self.user = ProfileFactory.create().user_object
+        self.privileged_profile = ProfileFactory()
+        self.privileged_user = self.privileged_profile.user_object
+        grant_privilege(self.privileged_user, 'Scheduling Mavens')
+ 
+
+    def test_no_login_gives_error(self):
+        url = reverse(self.view_name,
+                      urlconf="scheduler.urls")
+        response = self.client.get(url)
+        nt.assert_equal(response.status_code, 302)
+
+    def test_bad_user(self):
+        login_as(ProfileFactory(), self)
+        url = reverse(self.view_name,
+                      urlconf="scheduler.urls")
+        response = self.client.get(url)
+        nt.assert_equal(response.status_code, 403)
+
+    def test_good_user_first_load(self):
+        login_as(self.privileged_profile, self)
+        url = reverse(self.view_name,
+                      urlconf="scheduler.urls")
+        response = self.client.get(url)
+        nt.assert_equal(response.status_code, 200)

--- a/expo/tests/scheduler/test_event_list.py
+++ b/expo/tests/scheduler/test_event_list.py
@@ -6,11 +6,19 @@ from tests.factories.gbe_factories import (
     ProfileFactory,
     ShowFactory,
 )
+from gbe.models import Conference
 from tests.functions.gbe_functions import (
     current_conference,
     grant_privilege,
     login_as,
 )
+from tests.factories.scheduler_factories import (
+    SchedEventFactory,
+)
+from tests.contexts import (
+    ClassContext,
+)
+
 
 class TestEventList(TestCase):
     view_name = 'event_schedule'
@@ -21,7 +29,6 @@ class TestEventList(TestCase):
         self.privileged_profile = ProfileFactory()
         self.privileged_user = self.privileged_profile.user_object
         grant_privilege(self.privileged_user, 'Scheduling Mavens')
- 
 
     def test_no_login_gives_error(self):
         url = reverse(self.view_name,
@@ -36,9 +43,66 @@ class TestEventList(TestCase):
         response = self.client.get(url)
         nt.assert_equal(response.status_code, 403)
 
-    def test_good_user_first_load(self):
+    def test_good_user_get_success(self):
+        SchedEventFactory()
         login_as(self.privileged_profile, self)
         url = reverse(self.view_name,
                       urlconf="scheduler.urls")
         response = self.client.get(url)
         nt.assert_equal(response.status_code, 200)
+        nt.assert_true('Select event type to schedule' in response.content)
+        nt.assert_true(
+            '<option value="GenericEvent">GenericEvent</option>'
+            in response.content)
+        nt.assert_true(
+            '<option value="Class">Class</option>' in response.content)
+        nt.assert_true(
+            '<option value="Show">Show</option>' in response.content)
+
+    def test_good_user_post_class(self):
+        Conference.objects.all().delete()
+        context = ClassContext()
+        login_as(self.privileged_profile, self)
+        url = reverse(self.view_name,
+                      urlconf="scheduler.urls")
+        response = self.client.post(url,
+                                    data={'event_type': 'Class'})
+        nt.assert_equal(response.status_code, 200)
+        nt.assert_true(
+            context.sched_event.eventitem.describe in response.content)
+
+    def test_good_user_post_genericevent(self):
+        Conference.objects.all().delete()
+        event = SchedEventFactory()
+        login_as(self.privileged_profile, self)
+        url = reverse(self.view_name,
+                      urlconf="scheduler.urls")
+        response = self.client.post(url,
+                                    data={'event_type': 'GenericEvent'})
+        nt.assert_equal(response.status_code, 200)
+        nt.assert_true(
+            event.eventitem.describe in response.content)
+
+    def test_good_user_post_show(self):
+        Conference.objects.all().delete()
+        show = ShowFactory()
+        show_event = SchedEventFactory.create(eventitem=show.eventitem_ptr)
+        login_as(self.privileged_profile, self)
+        url = reverse(self.view_name,
+                      urlconf="scheduler.urls")
+        response = self.client.post(url,
+                                    data={'event_type': 'Show'})
+        nt.assert_equal(response.status_code, 200)
+        nt.assert_true(
+            show_event.eventitem.describe in response.content)
+
+    def test_good_user_post_event(self):
+        Conference.objects.all().delete()
+        login_as(self.privileged_profile, self)
+        url = reverse(self.view_name,
+                      urlconf="scheduler.urls")
+        response = self.client.post(url,
+                                    data={'event_type': 'Event'})
+        nt.assert_equal(response.status_code, 200)
+        nt.assert_true(
+            "Events Information" in response.content)


### PR DESCRIPTION
Closes #774 

There’s one line in “get_events_display_info” that I can’t get coverage for - line 111.  I’m wrestling with pulling it - it’s a fair line, but all the models we have would require serious messing around.  

EventFactory doesn’t work on it’s own (I get an error when I try to just create a raw EventFactory event - or that would be a decent vehicle for this case.
