### PR TITLE
GBE 794:  Reverse URL lookup to get to view_* (any bid)

### DIFF
--- a/expo/gbe/views/review_act_view.py
+++ b/expo/gbe/views/review_act_view.py
@@ -19,7 +19,6 @@ from gbe.forms import (
     BidStateChangeForm,
     PersonaForm,
 )
-from gbe.views import ViewActView
 from gbe.functions import (
     get_conf,
     validate_perms,
@@ -40,7 +39,8 @@ def ReviewActView(request, act_id):
     act = get_object_or_404(Act,
                             id=act_id)
     if not act.is_current:
-        return ViewActView(request, act_id)
+        return HttpResponseRedirect(
+            reverse('act_view', urlconf='gbe.urls', args=[act_id]))
     conference, old_bid = get_conf(act)
     audio_info = act.tech.audio
     stage_info = act.tech.stage

--- a/expo/gbe/views/review_class_view.py
+++ b/expo/gbe/views/review_class_view.py
@@ -39,7 +39,8 @@ def ReviewClassView(request, class_id):
         id=class_id,
     )
     if not aclass.is_current:
-        return view_class(request, class_id)
+        return HttpResponseRedirect(
+            reverse('class_view', urlconf='gbe.urls', args=[class_id]))
     conference, old_bid = get_conf(aclass)
     classform = ClassBidForm(instance=aclass, prefix='The Class')
     teacher = PersonaForm(instance=aclass.teacher,

--- a/expo/gbe/views/review_costume_view.py
+++ b/expo/gbe/views/review_costume_view.py
@@ -5,7 +5,6 @@ from django.shortcuts import (
     render,
     get_object_or_404,
 )
-
 from expo.gbe_logging import log_func
 from gbe.functions import (
     validate_perms,
@@ -40,7 +39,8 @@ def ReviewCostumeView(request, costume_id):
         id=costume_id
     )
     if not costume.is_current:
-        return view_costume(request, costume_id)
+        return HttpResponseRedirect(
+            reverse('costume_view', urlconf='gbe.urls', args=[costume_id]))
     conference, old_bid = get_conf(costume)
     costume_form = CostumeBidSubmitForm(instance=costume,
                                         prefix='Costume Proposal')

--- a/expo/gbe/views/review_vendor_view.py
+++ b/expo/gbe/views/review_vendor_view.py
@@ -22,6 +22,7 @@ from gbe.functions import (
 )
 
 
+@login_required
 @log_func
 def ReviewVendorView(request, vendor_id):
     '''

--- a/expo/gbe/views/review_volunteer_view.py
+++ b/expo/gbe/views/review_volunteer_view.py
@@ -45,7 +45,10 @@ def ReviewVolunteerView(request, volunteer_id):
         id=volunteer_id,
     )
     if not volunteer.is_current:
-        return view_volunteer(request, volunteer_id)
+        return HttpResponseRedirect(
+            reverse('volunteer_view',
+                    urlconf='gbe.urls',
+                    args=[volunteer_id]))
     conference, old_bid = get_conf(volunteer)
     volunteer_prof = volunteer.profile
     volform = VolunteerBidForm(

--- a/expo/tests/gbe/test_review_act.py
+++ b/expo/tests/gbe/test_review_act.py
@@ -38,8 +38,8 @@ class TestReviewAct(TestCase):
                       args=[act.pk])
         login_as(self.privileged_user, self)
         response = self.client.get(url)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Bid Information' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Bid Information' in response.content)
 
     def test_review_act_act_reviewer(self):
         act = ActFactory()
@@ -50,9 +50,9 @@ class TestReviewAct(TestCase):
         grant_privilege(staff_user, 'Act Reviewers')
         login_as(staff_user, self)
         response = self.client.get(url)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Bid Information' in response.content)
-        nt.assert_false('Bid Control for Coordinator' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Bid Information' in response.content)
+        self.assertTrue('Review Information' in response.content)
 
     def test_hidden_fields_are_populated(self):
         act = ActFactory()
@@ -67,8 +67,8 @@ class TestReviewAct(TestCase):
                            'type="hidden" value="%d" />') % staff_user.pk
         bid_id_input = ('<input id="id_bid" name="bid" type="hidden" '
                         'value="%d" />') % act.pk
-        nt.assert_true(evaluator_input in response.content)
-        nt.assert_true(bid_id_input in response.content)
+        self.assertTrue(evaluator_input in response.content)
+        self.assertTrue(bid_id_input in response.content)
 
     def test_review_act_old_act(self):
         conference = ConferenceFactory(status="completed",
@@ -78,9 +78,11 @@ class TestReviewAct(TestCase):
                       urlconf='gbe.urls',
                       args=[act.pk])
         login_as(self.privileged_user, self)
-        response = self.client.get(url)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Review Bids' in response.content)
+        response = self.client.get(url, follow=True)
+        self.assertRedirects(
+            response,
+            reverse('act_view', urlconf='gbe.urls', args=[act.pk]))
+        self.assertTrue('Review Bids' in response.content)
 
     def test_review_act_non_privileged_user(self):
         act = ActFactory()
@@ -89,7 +91,7 @@ class TestReviewAct(TestCase):
                       args=[act.pk])
         login_as(ProfileFactory(), self)
         response = self.client.get(url)
-        nt.assert_equal(403, response.status_code)
+        self.assertEqual(403, response.status_code)
 
     def test_review_act_act_post(self):
         clear_conferences()
@@ -111,12 +113,12 @@ class TestReviewAct(TestCase):
                                      'evaluator': profile.pk,
                                      'bid': act.pk},
                                     follow=True)
-        nt.assert_equal(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         expected_string = ("Bid Information for %s" %
                            conference.conference_name)
         error_string = "There is an error on the form"
-        nt.assert_true(expected_string in response.content)
-        nt.assert_false(error_string in response.content)
+        self.assertTrue(expected_string in response.content)
+        self.assertFalse(error_string in response.content)
 
     def test_review_act_act_post_invalid_form(self):
         clear_conferences()
@@ -137,6 +139,6 @@ class TestReviewAct(TestCase):
                                      'notes': "blah blah",
                                      'bid': act.pk},
                                     follow=True)
-        nt.assert_equal(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         expected_string = "There is an error on the form."
-        nt.assert_true(expected_string in response.content)
+        self.assertTrue(expected_string in response.content)

--- a/expo/tests/gbe/test_review_class.py
+++ b/expo/tests/gbe/test_review_class.py
@@ -1,16 +1,17 @@
-import nose.tools as nt
 from django.test import TestCase
 from django.test.client import RequestFactory
 from django.test import Client
 from django.core.urlresolvers import reverse
 from tests.factories.gbe_factories import (
-    PersonaFactory,
     ClassFactory,
+    ConferenceFactory,
+    PersonaFactory,
     ProfileFactory,
 )
 from tests.factories.scheduler_factories import SchedEventFactory
 from tests.functions.gbe_functions import (
     grant_privilege,
+    is_login_page,
     login_as,
 )
 
@@ -38,8 +39,8 @@ class TestReviewClass(TestCase):
 
         login_as(self.privileged_user, self)
         response = self.client.get(url)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Bid Information' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Bid Information' in response.content)
 
     def test_review_class_post_form_invalid(self):
         klass = ClassFactory()
@@ -50,8 +51,8 @@ class TestReviewClass(TestCase):
         login_as(self.privileged_user, self)
         response = self.client.post(url,
                                     data={'accepted': 1})
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Bid Information' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Bid Information' in response.content)
 
     def test_review_class_post_form_valid(self):
         klass = ClassFactory()
@@ -66,5 +67,33 @@ class TestReviewClass(TestCase):
                                      'evaluator': profile.pk,
                                      'bid': klass.pk},
                                     follow=True)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Bid Information' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Bid Information' in response.content)
+
+    def test_review_class_past_conference(self):
+        klass = ClassFactory()
+        klass.conference.status = 'completed'
+        klass.conference.save()
+        url = reverse(self.view_name, args=[klass.pk], urlconf="gbe.urls")
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assertRedirects(
+            response,
+            reverse('class_view',
+                    urlconf='gbe.urls',
+                    args=[klass.pk]))
+        self.assertTrue('Bid Information' in response.content)
+        self.assertFalse('Review Information' in response.content)
+
+    def test_no_login_gives_error(self):
+        url = reverse(self.view_name, args=[1], urlconf="gbe.urls")
+        response = self.client.get(url, follow=True)
+        redirect_url = reverse('login', urlconf='gbe.urls') + "/?next=" + url
+        self.assertRedirects(response, redirect_url)
+        self.assertTrue(is_login_page(response))
+
+    def test_bad_user(self):
+        login_as(ProfileFactory(), self)
+        url = reverse(self.view_name, args=[1], urlconf="gbe.urls")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)

--- a/expo/tests/gbe/test_review_costume.py
+++ b/expo/tests/gbe/test_review_costume.py
@@ -1,14 +1,15 @@
-import nose.tools as nt
 from django.test import TestCase
 from django.test import Client
 from django.core.urlresolvers import reverse
 from tests.factories.gbe_factories import (
+    ConferenceFactory,
     CostumeFactory,
     PersonaFactory,
     ProfileFactory,
 )
 from tests.functions.gbe_functions import (
     grant_privilege,
+    is_login_page,
     login_as,
 )
 
@@ -29,5 +30,32 @@ class TestReviewCostume(TestCase):
         url = reverse(self.view_name, args=[costume.pk], urlconf="gbe.urls")
         login_as(self.privileged_user, self)
         response = self.client.get(url)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Bid Information' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Bid Information' in response.content)
+
+    def test_review_costume_past_conference(self):
+        conference = ConferenceFactory(status='completed')
+        costume = CostumeFactory(conference=conference)
+        url = reverse(self.view_name, args=[costume.pk], urlconf="gbe.urls")
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assertRedirects(
+            response,
+            reverse('costume_view',
+                    urlconf='gbe.urls',
+                    args=[costume.pk]))
+        self.assertTrue('Bid Information' in response.content)
+        self.assertFalse('Review Information' in response.content)
+
+    def test_no_login_gives_error(self):
+        url = reverse(self.view_name, args=[1], urlconf="gbe.urls")
+        response = self.client.get(url, follow=True)
+        redirect_url = reverse('login', urlconf='gbe.urls') + "/?next=" + url
+        self.assertRedirects(response, redirect_url)
+        self.assertTrue(is_login_page(response))
+
+    def test_bad_user(self):
+        login_as(ProfileFactory(), self)
+        url = reverse(self.view_name, args=[1], urlconf="gbe.urls")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)

--- a/expo/tests/gbe/test_review_volunteer.py
+++ b/expo/tests/gbe/test_review_volunteer.py
@@ -132,4 +132,3 @@ class TestReviewVolunteer(TestCase):
         url = reverse(self.view_name, args=[1], urlconf="gbe.urls")
         response = self.client.get(url)
         self.assertEqual(response.status_code, 403)
-

--- a/expo/tests/gbe/test_review_volunteer.py
+++ b/expo/tests/gbe/test_review_volunteer.py
@@ -1,4 +1,3 @@
-import nose.tools as nt
 from django.test import TestCase
 from django.test import Client
 from django.core.urlresolvers import reverse
@@ -11,6 +10,7 @@ from tests.factories.gbe_factories import (
 )
 from tests.functions.gbe_functions import (
     grant_privilege,
+    is_login_page,
     login_as,
 )
 
@@ -46,9 +46,9 @@ class TestReviewVolunteer(TestCase):
 
         login_as(self.privileged_user, self)
         response = self.client.get(url)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Bid Information' in response.content)
-        nt.assert_false('Change Bid State:' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Bid Information' in response.content)
+        self.assertFalse('Change Bid State:' in response.content)
 
     def test_review_volunteer_get_conference(self):
         volunteer = VolunteerFactory()
@@ -60,9 +60,9 @@ class TestReviewVolunteer(TestCase):
         response = self.client.get(
             url,
             data={'conf_slug': volunteer.conference.id})
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Bid Information' in response.content)
-        nt.assert_false('Change Bid State:' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Bid Information' in response.content)
+        self.assertTrue('Review Information' in response.content)
 
     def test_review_volunteer_coordinator(self):
         volunteer = VolunteerFactory()
@@ -72,9 +72,10 @@ class TestReviewVolunteer(TestCase):
 
         login_as(self.coordinator, self)
         response = self.client.get(url)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Change Bid State:' in response.content)
-        nt.assert_true('Bid Information' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Change Bid State:' in response.content)
+        self.assertTrue('Bid Information' in response.content)
+        self.assertTrue('Review Information' in response.content)
 
     def test_review_volunteer_post_invalid(self):
         volunteer = VolunteerFactory()
@@ -85,9 +86,9 @@ class TestReviewVolunteer(TestCase):
         login_as(self.coordinator, self)
         data = self.get_form(volunteer, self.coordinator, invalid=True)
         response = self.client.post(url, data=data)
-        nt.assert_equal(response.status_code, 200)
-        nt.assert_true('Change Bid State:' in response.content)
-        nt.assert_true('Bid Information' in response.content)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Change Bid State:' in response.content)
+        self.assertTrue('Bid Information' in response.content)
 
     def test_review_volunteer_post_valid(self):
         volunteer = VolunteerFactory()
@@ -98,9 +99,37 @@ class TestReviewVolunteer(TestCase):
         login_as(self.coordinator, self)
         data = self.get_form(volunteer, self.coordinator)
         response = self.client.post(url, data=data, follow=True)
-        nt.assert_equal(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
         html_tag = '<h2 class="review-title">%s</h2>'
         title_string = ("Bid Information for %s" %
                         volunteer.conference.conference_name)
         html_title = html_tag % title_string
         assert html_title in response.content
+
+    def test_review_volunteer_past_conference(self):
+        conference = ConferenceFactory(status='completed')
+        volunteer = VolunteerFactory(conference=conference)
+        url = reverse(self.view_name, args=[volunteer.pk], urlconf="gbe.urls")
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assertRedirects(
+            response,
+            reverse('volunteer_view',
+                    urlconf='gbe.urls',
+                    args=[volunteer.pk]))
+        self.assertTrue('Bid Information' in response.content)
+        self.assertFalse('Review Information' in response.content)
+
+    def test_no_login_gives_error(self):
+        url = reverse(self.view_name, args=[1], urlconf="gbe.urls")
+        response = self.client.get(url, follow=True)
+        redirect_url = reverse('login', urlconf='gbe.urls') + "/?next=" + url
+        self.assertRedirects(response, redirect_url)
+        self.assertTrue(is_login_page(response))
+
+    def test_bad_user(self):
+        login_as(ProfileFactory(), self)
+        url = reverse(self.view_name, args=[1], urlconf="gbe.urls")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+


### PR DESCRIPTION
looked at the bug and saw we had inconsistent implementation across functions in the various mappings from review_(bid type) to the view_(bid type) when the conference has passed.

I made them all reverse url lookups, and then wrote tests for that in every test area.  Also noticed some test collections that didn’t include a login and permission check and so added those, too. 

Lastly, any test case I touched, I refactored to remove nose.

Fixes #794 