### PR TITLE
GBE 817 - fix for errors in Act Tech Info submit cause messed up information display on top of page.

### DIFF
--- a/expo/gbe/views/edit_act_techinfo_view.py
+++ b/expo/gbe/views/edit_act_techinfo_view.py
@@ -34,67 +34,6 @@ from gbe.forms import (
 from scheduler.models import Event as sEvent
 
 
-def set_rehearsal_forms(shows, act):
-    '''
-    Sets up any forms for shows with scheduled rehearsal sets.
-        shows = a list of shows to build rehearsal sets for
-        act = the act that is the current working element for the forms
-        return value = a set of RehearsalSelectionForm, one
-            for each show that has some *open* rehearsals scheduled
-            (open = has available slots to add acts to)
-            with the scheduled rehearsals for this act selected
-    '''
-    rehearsal_sets = {}
-    existing_rehearsals = {}
-    
-    if show_detail.cue_sheet == 'Theater':
-        formtype = CueInfoForm
-    elif show_detail.cue_sheet == 'Alternate':
-        formtype = VendorCueInfoForm
-    else:
-        formtype = "None"
-
-    form = ActTechInfoForm(instance=act,
-                               prefix='act_tech_info')
-    q = Performer.objects.filter(contact=profile)
-    form.fields['performer'] = ModelChoiceField(queryset=q)
-
-    for show in shows:
-        re_set = show.get_open_rehearsals()
-        existing_rehearsal = None
-        try:
-            existing_rehearsal = [r for r in act.get_scheduled_rehearsals() if
-                                  r.container_event.parent_event == show][0]
-        except:
-            pass
-        if existing_rehearsal:
-            existing_rehearsals[show] = existing_rehearsal
-            # show chosen rehearsal, even if it doesn't have an open slot
-            if existing_rehearsal not in re_set:
-                re_set.append(existing_rehearsal)
-                re_set = sorted(
-                    re_set,
-                    key=lambda sched_event: sched_event.starttime)
-
-        if len(re_set) > 0:
-            rehearsal_sets[show] = re_set
-
-    if len(rehearsal_sets) > 0:
-        for (show, r_set) in rehearsal_sets.items():
-            initial = {
-                'show': show,
-                'rehearsal_choices':
-                    [(r.id, "%s: %s" % (
-                        r.as_subtype.title,
-                        r.starttime.strftime("%I:%M:%p"))) for r in r_set]}
-            if show in existing_rehearsals:
-                initial['rehearsal'] = existing_rehearsals[show].id
-            rehearsal_forms += [
-                RehearsalSelectionForm(
-                    initial=initial)]
-    return rehearsal_forms
-
-
 @login_required
 @log_func
 def EditActTechInfoView(request, act_id):
@@ -123,7 +62,58 @@ def EditActTechInfoView(request, act_id):
 
     shows = act.get_scheduled_shows()
     show_detail = get_object_or_404(Show, eventitem_id=shows[0].eventitem.pk)
-    rehearsal_forms = set_rehearsal_forms(shows, act)
+    rehearsal_sets = {}
+    existing_rehearsals = {}
+    
+    if show_detail.cue_sheet == 'Theater':
+        formtype = CueInfoForm
+    elif show_detail.cue_sheet == 'Alternate':
+        formtype = VendorCueInfoForm
+    else:
+        formtype = "None"
+
+    form = ActTechInfoForm(instance=act,
+                               prefix='act_tech_info')
+    q = Performer.objects.filter(contact=profile)
+    form.fields['performer'] = ModelChoiceField(queryset=q)
+
+    for show in shows:
+        re_set = show.get_open_rehearsals()
+        existing_rehearsal = None
+        try:
+            existing_rehearsal = [r for r in act.get_scheduled_rehearsals() if
+                                  r.container_event.parent_event == show][0]
+        except:
+            pass
+        if existing_rehearsal:
+            try:
+                re_set.remove(existing_rehearsal)
+            except:
+                pass
+            re_set.append(existing_rehearsal)
+            re_set = sorted(re_set,
+                            key=lambda sched_event: sched_event.starttime)
+            existing_rehearsals[show] = existing_rehearsal
+
+        if len(re_set) > 0:
+            rehearsal_sets[show] = re_set
+
+    if len(rehearsal_sets) > 0:
+        rehearsal_forms = []
+        for (show, r_set) in rehearsal_sets.items():
+            initial = {
+                'show': show,
+                'rehearsal_choices':
+                    [(r.id, "%s: %s" % (
+                        r.as_subtype.title,
+                        r.starttime.strftime("%I:%M:%p"))) for r in r_set]}
+            if show in existing_rehearsals:
+                initial['rehearsal'] = existing_rehearsals[show].id
+            rehearsal_forms += [
+                RehearsalSelectionForm(
+                    initial=initial)]
+    else:
+        rehearsal_forms = []
 
     if request.method == 'POST':
         if 'rehearsal' in request.POST:

--- a/expo/gbe/views/edit_act_techinfo_view.py
+++ b/expo/gbe/views/edit_act_techinfo_view.py
@@ -64,6 +64,19 @@ def EditActTechInfoView(request, act_id):
     show_detail = get_object_or_404(Show, eventitem_id=shows[0].eventitem.pk)
     rehearsal_sets = {}
     existing_rehearsals = {}
+    
+    if show_detail.cue_sheet == 'Theater':
+        formtype = CueInfoForm
+    elif show_detail.cue_sheet == 'Alternate':
+        formtype = VendorCueInfoForm
+    else:
+        formtype = "None"
+
+    form = ActTechInfoForm(instance=act,
+                               prefix='act_tech_info')
+    q = Performer.objects.filter(contact=profile)
+    form.fields['performer'] = ModelChoiceField(queryset=q)
+
     for show in shows:
         re_set = show.get_open_rehearsals()
         existing_rehearsal = None
@@ -110,9 +123,6 @@ def EditActTechInfoView(request, act_id):
                 Show,
                 title=request.POST['show']).scheduler_events.first()
             act.set_rehearsal(show, rehearsal)
-        form = ActTechInfoForm(request.POST,
-                               instance=act,
-                               prefix='act_tech_info')
         audioform = AudioInfoSubmitForm(request.POST,
                                         request.FILES,
                                         prefix='audio_info',
@@ -123,12 +133,6 @@ def EditActTechInfoView(request, act_id):
         lightingform = LightingInfoForm(request.POST,
                                         prefix='lighting_info',
                                         instance=lighting_info)
-        if show_detail.cue_sheet == 'Theater':
-            formtype = CueInfoForm
-        elif show_detail.cue_sheet == 'Alternate':
-            formtype = VendorCueInfoForm
-        else:
-            formtype = "None"
 
         cue_fail = False
         if formtype != "None":
@@ -170,8 +174,6 @@ def EditActTechInfoView(request, act_id):
                           'gbe/act_techinfo.tmpl',
                           form_data)
     else:
-        form = ActTechInfoForm(instance=act,
-                               prefix='act_tech_info')
         audioform = AudioInfoSubmitForm(prefix='audio_info',
                                         instance=audio_info)
         stageform = StageInfoSubmitForm(prefix='stage_info',
@@ -179,13 +181,6 @@ def EditActTechInfoView(request, act_id):
         lightingform = LightingInfoForm(prefix='lighting_info',
                                         instance=lighting_info)
         techforms = [lightingform, audioform, stageform, ]
-
-        if show_detail.cue_sheet == 'Theater':
-            formtype = CueInfoForm
-        elif show_detail.cue_sheet == 'Alternate':
-            formtype = VendorCueInfoForm
-        else:
-            formtype = "None"
 
         form_data = {'readonlyform': [form],
                      'rehearsal_forms': rehearsal_forms,
@@ -204,9 +199,6 @@ def EditActTechInfoView(request, act_id):
                 choices=starting_cues,
                 initial=starting_cues[0])
             form_data['cues'] = cue_forms
-
-        q = Performer.objects.filter(contact=profile)
-        form.fields['performer'] = ModelChoiceField(queryset=q)
 
         return render(request,
                       'gbe/act_techinfo.tmpl',

--- a/expo/gbe_forms_text.py
+++ b/expo/gbe_forms_text.py
@@ -134,7 +134,7 @@ volunteer_interests_options = [('VA8', 'Art Show'),
                                ('VA6', 'Vendor room')]
 
 volunteer_labels = {
-    'number_shifts': 'How many shifts would you like to work?',
+    'number_shifts': 'How many hours would you like to work?',
     'interests': 'What are your particular areas of interest?',
     'availability': 'I am Available....',
     'unavailability': 'I am Not Available....',

--- a/expo/gbe_forms_text.py
+++ b/expo/gbe_forms_text.py
@@ -134,7 +134,7 @@ volunteer_interests_options = [('VA8', 'Art Show'),
                                ('VA6', 'Vendor room')]
 
 volunteer_labels = {
-    'number_shifts': 'How many hours would you like to work?',
+    'number_shifts': 'How many shifts would you like to work?',
     'interests': 'What are your particular areas of interest?',
     'availability': 'I am Available....',
     'unavailability': 'I am Not Available....',


### PR DESCRIPTION
Makes the failing test pass.
Refactored code to use the same act info setup code regardless of post
or get, and used the working get process instead of the post process.

A way to see the problem in integration is to follow the steps of #817 before and after the fix.

closes #817 