### PR TITLE
GBE-831: Lock down cmsplugin-filer and django-nose to versions that

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -3,14 +3,14 @@ MySQL-python==1.2.3
 South
 Pillow
 cmsplugin-bootstrap-carousel==0.2.2
-cmsplugin-filer
+cmsplugin-filer==1.0
 -e git://github.com/bethlakshmi/cmsplugin-image-gallery.git@53f60e1624e0785ad0fe09396dd49c555038c138#egg=cmsplugin_image_gallery-master
 cmsplugin-nivoslider==0.5.9
 django-classy-tags==0.6.1
 django-cms==3.1.1
 django-model-utils==2.2
 django-mptt==0.6.1
-django-nose
+django-nose==1.4.1
 django-polymorphic==0.6.1
 django-polymorphic-tree==1.0.1
 django-filer==0.9.11


### PR DESCRIPTION
support our configuration. 

To test, pull a new clone of the repo. Stand up the vagrant box and attempt to run tests or get into the django shell - should fail. Then check out this branch and do a 
`vagrant reload --provision
`
or 
`vagrant destroy
vagrant up
`

Then ssh in and run tests. Should succeed. 