### PR TITLE
GBE 828:  Django-debug-toolbar arrives

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -48,3 +48,4 @@ django-compat
 django-hijack
 ipython
 pep8
+django-debug-toolbar==1.3.2

--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -136,7 +136,7 @@ INSTALLED_APPS = (
     'django_nose',
     'hijack',
     'compat',
-
+    'debug_toolbar',
 )
 
 
@@ -155,6 +155,7 @@ THUMBNAIL_PROCESSORS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.cache.UpdateCacheMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -173,6 +174,7 @@ MIDDLEWARE_CLASSES = (
     'cms.middleware.language.LanguageCookieMiddleware',
     # end of add for django-cms
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
+    'django.middleware.cache.FetchFromCacheMiddleware',
 )
 
 TEXT_SAVE_IMAGE_FUNCTION = \


### PR DESCRIPTION
This needs one additional change - in your local_settings.py add:

INTERNAL_IPS = (
    ‘your_ip_here’)

The IP address has to be the address of the browser you’re connecting from.  I found this using a variant of this trick:

http://stackoverflow.com/a/14697123/49962

to get my settings to work correctly.

The verification is:
- the debug toolbar shows up when you navigate to our site in your browser (if the local settings are debug set to True)
- unit tests run

I’ll say honestly - the toolbar slows execution to a crawl, so we may need to debug to do other testing, but the SQL panel is pointing out some inefficiencies that I’m eager to fix (500+ queries on the /gbe landing page, 2000+ queries on one of the bid review pages) - so it’s definitely useful.

