### PR TITLE
GBE-844: This is why we can't run on webfactional

### DIFF
--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -138,7 +138,7 @@ INSTALLED_APPS = (
     'compat',
     'debug_toolbar',
 )
-
+DEBUG_TOOLBAR_PATCH_SETTINGS = False 
 
 FIXTURE_DIRS = ('expo/tests/fixtures',)
 


### PR DESCRIPTION
There’s a missing line that matters when you run in Apache rather than ./manage.py run server.