### PR TITLE
GBE-866: Prevent server error if user has two existing acts with name conflicts

### DIFF
--- a/expo/gbe/views/act_display_functions.py
+++ b/expo/gbe/views/act_display_functions.py
@@ -19,10 +19,10 @@ def display_invalid_act(request, data, form, conference, profile, view):
             defaults={
                 'summary': "Act Title, User, Conference Conflict",
                 'description': default_act_title_conflict})
-        conflict = Act.objects.get(
+        conflict = Act.objects.filter(
             conference=conference,
             title=form.data['theact-title'],
-            performer__contact=profile)
+            performer__contact=profile).first()
         if conflict.submitted:
             link = reverse(
                 'act_view',


### PR DESCRIPTION
This shouldn't happen, but if someone does have two acts with conflicting names the get() call fails hard. This is not a great solution - it redirects them to one of the two conflicting acts - but at least it doesn't die in flames. 