### PR TITLE
GBE-255: add an ad-rotator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ htmlcov
 expo/.coverage
 
 .cache/v/cache/lastfailed
+
+expo/src/cmsplugin-image-gallery-master/

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -50,3 +50,4 @@ ipython
 pep8
 django-debug-toolbar==1.3.2
 wand
+django-ad-rotator

--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -137,8 +137,9 @@ INSTALLED_APPS = (
     'hijack',
     'compat',
     'debug_toolbar',
+    'ad_rotator',
 )
-DEBUG_TOOLBAR_PATCH_SETTINGS = False 
+DEBUG_TOOLBAR_PATCH_SETTINGS = False
 
 FIXTURE_DIRS = ('expo/tests/fixtures',)
 

--- a/expo/gbe/cms_plugins.py
+++ b/expo/gbe/cms_plugins.py
@@ -5,7 +5,7 @@ from django.template import loader
 from gbe.forms import (
     ContactForm,
     ClassProposalForm,
-    )
+)
 
 from cms.models.pluginmodel import CMSPlugin
 from django.core.urlresolvers import reverse

--- a/expo/gbe/cms_plugins.py
+++ b/expo/gbe/cms_plugins.py
@@ -65,6 +65,12 @@ class FollowOnFacebookPlugin(CMSPluginBase):
     render_template = loader.get_template('gbe/facebook_follow.tmpl')
 
 
+class AdRotatorPlugin(CMSPluginBase):
+    model = CMSPlugin
+    module = _("GBE Plugins")
+    name = _("Ad Rotator")
+    render_template = loader.get_template('gbe/ad-rotator.tmpl')
+
 # register the plugins
 plugin_pool.register_plugin(ClassIdeaPlugin)
 plugin_pool.register_plugin(ContactFormPlugin)
@@ -72,3 +78,4 @@ plugin_pool.register_plugin(SubscribeEmailPlugin)
 plugin_pool.register_plugin(GoFundMePlugin)
 plugin_pool.register_plugin(ShareOnFacebookPlugin)
 plugin_pool.register_plugin(FollowOnFacebookPlugin)
+plugin_pool.register_plugin(AdRotatorPlugin)

--- a/expo/gbe/templates/gbe/ad-rotator.tmpl
+++ b/expo/gbe/templates/gbe/ad-rotator.tmpl
@@ -1,0 +1,2 @@
+{% load ad_rotator_tags %}
+{% get_banner %}

--- a/expo/tests/gbe/test_gbe_cms_plugins.py
+++ b/expo/tests/gbe/test_gbe_cms_plugins.py
@@ -1,0 +1,51 @@
+from django.test import TestCase
+from django.core.urlresolvers import reverse
+
+from cms.api import add_plugin
+from cms.models import Placeholder
+
+from gbe.cms_plugins import (
+    ClassIdeaPlugin,
+    ContactFormPlugin,
+)
+from gbe.forms import (
+    ContactForm,
+    ClassProposalForm,
+)
+
+class ClassIdeaPluginTests(TestCase):
+    
+    def test_plugin_context(self):
+        placeholder = Placeholder.objects.create(slot='test')
+        model_instance = add_plugin(
+            placeholder,
+            ClassIdeaPlugin,
+            'en',
+        )
+        plugin_instance = model_instance.get_plugin_class_instance()
+        context = plugin_instance.render({}, model_instance, None)
+        self.assertIn('forms', context)
+        self.assertEqual(type(context['forms'][0]),
+                         type(ClassProposalForm()))
+        self.assertEqual(len(context['forms']), 1)
+        self.assertIn('bid_destination', context)
+        self.assertEqual(context['bid_destination'],
+                         reverse('class_propose',
+                                 urlconf='gbe.urls'))
+        self.assertIn('nodraft', context)
+        self.assertEqual(context['nodraft'], 'Submit')
+
+class ContactFormPluginTests(TestCase):
+    
+    def test_plugin_context(self):
+        placeholder = Placeholder.objects.create(slot='test')
+        model_instance = add_plugin(
+            placeholder,
+            ContactFormPlugin,
+            'en',
+        )
+        plugin_instance = model_instance.get_plugin_class_instance()
+        context = plugin_instance.render({}, model_instance, None)
+        self.assertIn('contact_form', context)
+        self.assertEqual(type(context['contact_form']),
+                         type(ContactForm()))


### PR DESCRIPTION
- needs a reprovision of vagrant.
- after reprovision and re-setup, do a migrate

you can see the work manually by:
- go to localhost:####
- use a user that can edit django-cms (scratch and betty can)
- in the top white bar, click edit
- click structure
- insert a plugin in any box (it’s inserted through the menu in the upper right hand corner of the box.
- plugin is in the GBE area and called Ad Rotator.

——
Then go to /admin
- see that there is now “Ad_Rotator”
- and in it “Banner ads”
- you have to add banner ad items with start/end dates before and after now.

——
When you’ve set up both a page with the banner ad, and the images themselves, the ad picture will appear on refresh