### PR TITLE
GBE-655:  Better volunteer info on assignment to opportunity.

### DIFF
--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -163,17 +163,3 @@ def eligible_volunteers(event_start_time, event_end_time, conference):
     return Volunteer.objects.filter(
         conference=conference).exclude(
         unavailable_windows__in=windows)
-
-
-def show_potential_workers(category, start_time, end_time, conference):
-    '''
-    Get lists of potential workers for this opportunity.
-      - interested_volunteers - rated the interest above "neither interested
-         or disinterested"
-      - available_volunteers - have the time available
-      - all_volunteers - everyone who offered ... ever
-    '''
-    eligible = eligible_volunteers(start_time, end_time, conference)
-    return {'interested_volunteers': eligible,
-            'all_volunteers': eligible,
-            'available_volunteers': eligible}

--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -148,12 +148,6 @@ def get_events_list_by_type(event_type, conference):
     return items
 
 
-'''
-#  eligible = not unavailable.  VolunteerBid lets the user select available
-#     and unavailable times.  Eligible volunteers have said they were
-#     unavailable in the volunteer time window(s) that correspond to this
-#     event AND bid their time for this conference.
-'''
 def eligible_volunteers(event_start_time, event_end_time, conference):
     windows = []
     for window in conference.windows():

--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -1,5 +1,3 @@
-import pytz
-from datetime import datetime, timedelta
 from gbe.models import (
     Class,
     Conference,
@@ -19,7 +17,6 @@ from gbetext import (
     event_options,
     class_options,
 )
-from gbe.duration import DateTimeRange
 from scheduler.models import Event as sEvent
 
 
@@ -151,22 +148,24 @@ def get_events_list_by_type(event_type, conference):
     return items
 
 
-def available_volunteers(event_start_time, conference):
-    one_minute = timedelta(0, 60)
-    tz = pytz.utc
-    event_start_time = event_start_time + one_minute
+'''
+#  eligible = not unavailable.  VolunteerBid lets the user select available
+#     and unavailable times.  Eligible volunteers have said they were
+#     unavailable in the volunteer time window(s) that correspond to this
+#     event AND bid their time for this conference.
+'''
+def eligible_volunteers(event_start_time, event_end_time, conference):
     windows = []
     for window in conference.windows():
-        starttime = tz.localize(datetime.combine(window.day.day, window.start))
-        endtime = tz.localize(datetime.combine(window.day.day, window.end))
-        window_range = DateTimeRange(starttime=starttime,
-                                     endtime=endtime)
-        if event_start_time in window_range:
+        if window.check_conflict(event_start_time, event_end_time):
             windows.append(window)
-    return Volunteer.objects.filter(available_windows__in=windows)
+
+    return Volunteer.objects.filter(
+        conference=conference).exclude(
+        unavailable_windows__in=windows)
 
 
-def show_potential_workers(category, start_time, conference):
+def show_potential_workers(category, start_time, end_time, conference):
     '''
     Get lists of potential workers for this opportunity.
       - interested_volunteers - rated the interest above "neither interested
@@ -174,11 +173,7 @@ def show_potential_workers(category, start_time, conference):
       - available_volunteers - have the time available
       - all_volunteers - everyone who offered ... ever
     '''
-    interested = list(Volunteer.objects.filter(
-        volunteerinterest__rank__gt=3,
-        volunteerinterest__interest=category))
-    all_volunteers = list(Volunteer.objects.all())
-    available = available_volunteers(start_time, conference)
-    return {'interested_volunteers': interested,
-            'all_volunteers': all_volunteers,
-            'available_volunteers': available}
+    eligible = eligible_volunteers(start_time, end_time, conference)
+    return {'interested_volunteers': eligible,
+            'all_volunteers': eligible,
+            'available_volunteers': eligible}

--- a/expo/gbe/models/remains.py
+++ b/expo/gbe/models/remains.py
@@ -110,6 +110,23 @@ class VolunteerWindow(models.Model):
                                  self.start.strftime("%I:%M %p"),
                                  self.end.strftime("%I:%M %p"))
 
+    def check_conflict(self, start, end):
+        tz = pytz.utc
+        starttime = tz.localize(datetime.combine(self.day.day, self.start))
+        endtime = tz.localize(datetime.combine(self.day.day, self.end))
+        has_conflict = False
+
+        if start == starttime:
+            has_conflict = True
+        elif (start > starttime and
+              start < endtime):
+            has_conflict.append(window)
+        elif (start < starttime and
+              end > starttime):
+            has_conflict.append(window)
+            
+        return has_conflict
+
     class Meta:
         ordering = ['day', 'start']
         verbose_name = "Volunteer Window"

--- a/expo/gbe/models/remains.py
+++ b/expo/gbe/models/remains.py
@@ -110,20 +110,25 @@ class VolunteerWindow(models.Model):
                                  self.start.strftime("%I:%M %p"),
                                  self.end.strftime("%I:%M %p"))
 
+    def start_timestamp(self):
+        return pytz.utc.localize(datetime.combine(self.day.day, self.start))
+
+    def end_timestamp(self):
+        return pytz.utc.localize(datetime.combine(self.day.day, self.end))
+
     def check_conflict(self, start, end):
-        tz = pytz.utc
-        starttime = tz.localize(datetime.combine(self.day.day, self.start))
-        endtime = tz.localize(datetime.combine(self.day.day, self.end))
+        starttime = self.start_timestamp()
+        endtime = self.end_timestamp()
         has_conflict = False
 
         if start == starttime:
             has_conflict = True
         elif (start > starttime and
               start < endtime):
-            has_conflict.append(window)
+            has_conflict = True
         elif (start < starttime and
               end > starttime):
-            has_conflict.append(window)
+            has_conflict = True
             
         return has_conflict
 
@@ -1593,6 +1598,21 @@ class Volunteer(Biddable):
             visible_bid_query,
             submitted=True,
             accepted=0)
+
+    def check_available(self, start, end):
+        available = "Not Available"
+        for window in self.available_windows.all():
+            starttime = window.start_timestamp()
+            endtime = window.end_timestamp()
+            if start == starttime:
+                available = "Available"
+            elif (start > starttime and
+                  start < endtime):
+                available = "Available"
+            elif (start < starttime and
+                   end > starttime):
+                available = "Available"
+        return available
 
     class Meta:
         app_label = "gbe"

--- a/expo/gbe/models/remains.py
+++ b/expo/gbe/models/remains.py
@@ -129,7 +129,6 @@ class VolunteerWindow(models.Model):
         elif (start < starttime and
               end > starttime):
             has_conflict = True
-            
         return has_conflict
 
     class Meta:
@@ -1610,7 +1609,7 @@ class Volunteer(Biddable):
                   start < endtime):
                 available = "Available"
             elif (start < starttime and
-                   end > starttime):
+                  end > starttime):
                 available = "Available"
         return available
 

--- a/expo/scheduler/templates/scheduler/allocate_volunteers.tmpl
+++ b/expo/scheduler/templates/scheduler/allocate_volunteers.tmpl
@@ -41,6 +41,7 @@ included in event edit flow. Show WorkerAllocationForms
 
   </table>
   <hr>
+  {% if eligible_volunteers %}
   <h2>Volunteers for {{ eventitem.event.get_conference }}</h2>
   <div>Press the arrows to sort on a column.  To sort on an additional sub-order,
   press "Shift" to sort a secondary column.</div>
@@ -112,6 +113,9 @@ included in event edit flow. Show WorkerAllocationForms
     </tbody>
   </table>
   <br><br>
+{% else %}
+  There are no available volunteers in the current set of volunteer bids.
+{% endif %}
 </div>
 
   <script>

--- a/expo/scheduler/templates/scheduler/allocate_volunteers.tmpl
+++ b/expo/scheduler/templates/scheduler/allocate_volunteers.tmpl
@@ -116,7 +116,11 @@ included in event edit flow. Show WorkerAllocationForms
 
   <script>
   $(document).ready(function() {
-    var table = $('#volunteer_info').DataTable();
+    var table = $('#volunteer_info').DataTable( {
+        "order": [[ 3, "desc" ],
+		  [ 1, "desc" ],
+		  [ 2, "asc" ]]
+    } );
 
     $('a.toggle-vis').on( 'click', function (e) {
         e.preventDefault();

--- a/expo/scheduler/templates/scheduler/allocate_volunteers.tmpl
+++ b/expo/scheduler/templates/scheduler/allocate_volunteers.tmpl
@@ -42,55 +42,90 @@ included in event edit flow. Show WorkerAllocationForms
   </table>
   <hr>
   <h2>Volunteers for {{ eventitem.event.get_conference }}</h2>
-  <table>
-	<tr>
-		<td> 
-		     All Volunteers<br>
-			<form action = "{% url 'gbe:volunteer_review' 0 %}" method = 'POST'>
-			      {% csrf_token %}
-				<select id = 'volunteer' name = 'volunteer'>
-				{% for vol in all_volunteers %}
-				   <option value = {{vol.id}}> {{ vol }} </option>
-				{% endfor %}
-				</select> <br>
-				<input type = "submit" name = "review_all" value = "Review Volunteer">
-				
-							
-			</form>
-		</td>	
-		<td>
-			Interested Volunteers<br>
-			<form action = "{% url 'gbe:volunteer_review' 0 %}" method = 'POST'>
-			      	{% csrf_token %}	      	     
-				<select id = 'volunteer' name = 'volunteer'>
-				{% for vol in interested_volunteers %}
-				   <option value = {{vol.id}}> {{ vol }} </option>
-				{% endfor %}
-				</select><br>
-				<input type = "submit" name = "review_interested" value = "Review Volunteer">
-				
-							
-			</form>
-
-		</td>
-		<td>
-			Available Volunteers<br>
-			<form action = "{% url 'gbe:volunteer_review' 0 %}" method = 'POST'>
-			      	{% csrf_token %}	      	     
-				<select id = 'volunteer' name = 'volunteer'>
-				{% for vol in available_volunteers %}
-				   <option value = {{vol.id}}> {{ vol }} </option>
-				{% endfor %}
-				</select><br>
-				<input type = "submit" name = "review_interested" value = "Review Volunteer">
-				
-							
-			</form>
-
-		</td>
-			
-				
+  <div>Press the arrows to sort on a column.  To sort on an additional sub-order,
+  press "Shift" to sort a secondary column.</div>
+  <br/>
+  <div>
+    Toggle column(s):
+      <a class="toggle-vis" data-column="0">Display Name</a> - 
+      <a class="toggle-vis" data-column="1">Interest</a> - 
+      <a class="toggle-vis" data-column="2">Available</a> - 
+      <a class="toggle-vis" data-column="3">Conflict</a>
+  </div>
+  <br/>
+  <table id="volunteer_info" class="order-column" cellspacing="0" width="100%">
+    <thead>
+      <tr class="bid-table">
+        <th class="bid-table">Display Name</th>
+        <th class="bid-table">Interest</th>
+        <th class="bid-table">Available</th>
+        <th class="bid-table">Conflict</th>
+        <th class="bid-table">Review</th>
+        <th class="bid-table">Assign</th>
+      </tr>
+    </thead>
+    <tfoot>
+      <tr class="bid-table">
+        <th class="bid-table">Display Name</th>
+        <th class="bid-table">Interest</th>
+        <th class="bid-table">Available</th>
+        <th class="bid-table">Conflict</th>
+        <th class="bid-table">Review</th>
+        <th class="bid-table">Assign</th>
+      </tr>
+    </tfoot>
+    <tbody>
+    {% for volunteer in eligible_volunteers %}
+      <tr class="bid-table">
+        <td class="bid-table">{{ volunteer.display_name }}</td>
+        <td class="bid-table">{% if volunteer.interest.0 > 0 %}
+	  {{ volunteer.interest.0 }} - {{ volunteer.interest.1 }}
+	  {% else %}&nbsp;{% endif %}</td>
+        <td class="bid-table">{{ volunteer.available }}</td>
+        <td class="bid-table">
+	{% for conflict in volunteer.conflicts %}
+          <a href="{%url 'scheduler:edit_event' conflict.event_type_name conflict.pk %}">
+	    {{ conflict }}
+	  </a></br>
+	{% empty %}&nbsp;{% endfor %}
+        </td>
+	<td class="bid-table"><a href="{%url 'gbe:volunteer_review' volunteer.id %}">Review</a></td>
+        <td class="bid-table">
+	  <form method="POST" action="{% url 'scheduler:allocate_workers'  opp_id %}">
+            {% csrf_token %}
+  	    {% for field in volunteer.assign_form.visible_fields %}
+            {{ field }}
+            {% if field.errors %}
+              </br>
+              <font color="red">{{ field.errors }}</font>
+            {% endif %}
+	    </br>
+  	    {% endfor %}	    	
+	    {% for field in volunteer.assign_form.hidden_fields %}
+	      {{field}}
+	    {% endfor %}
+	    <input type = "submit" name="edit" value="Assign">
+	  </form>
+        </td>
+      </tr>
+    {% endfor %}
+    </tbody>
   </table>
   <br><br>
 </div>
 
+  <script>
+  $(document).ready(function() {
+    var table = $('#volunteer_info').DataTable();
+
+    $('a.toggle-vis').on( 'click', function (e) {
+        e.preventDefault();
+
+        // Get the column API object
+        var column = table.column( $(this).attr('data-column') );
+
+        // Toggle the visibility
+        column.visible( ! column.visible() );
+    } );
+} );
+  </script>

--- a/expo/scheduler/templates/scheduler/allocate_volunteers.tmpl
+++ b/expo/scheduler/templates/scheduler/allocate_volunteers.tmpl
@@ -41,7 +41,7 @@ included in event edit flow. Show WorkerAllocationForms
 
   </table>
   <hr>
-  <h2>Volunteer Info</h2>
+  <h2>Volunteers for {{ eventitem.event.get_conference }}</h2>
   <table>
 	<tr>
 		<td> 

--- a/expo/scheduler/templates/scheduler/event_schedule.tmpl
+++ b/expo/scheduler/templates/scheduler/event_schedule.tmpl
@@ -31,6 +31,13 @@
         {% endfor %}
 
        </div>
+   
+  {% if form %}
+  <form method="POST" action="{{event_edit_url}}" enctype="multipart/form-data">
+
+  {% include "form_table.tmpl" %}
+  <input type = "submit" name="submit" value="Submit">
+  </form>
       </div>
       {% if eventitem.scheduled_events %}
       <div class="sched_times">
@@ -42,17 +49,8 @@
 	  {% endfor %}
       </div>
       {% endif %}
+  </div>
 
-    </div>
-   
-
-
-  {% if form %}
-  <form method="POST" action="{{event_edit_url}}" enctype="multipart/form-data">
-
-  {% include "form_table.tmpl" %}
-  <input type = "submit" name="submit" value="Submit">
-  </form>
     {% if event_id %}
     <table> 
     <tr>
@@ -69,6 +67,7 @@
     </table>
     {% endif %}
   {% endif %}
+
 
   {% if worker_alloc_forms %}
   {% include "scheduler/allocate_volunteers.tmpl" %}

--- a/expo/scheduler/views.py
+++ b/expo/scheduler/views.py
@@ -474,6 +474,7 @@ def allocate_workers(request, opp_id):
 
     elif not form.is_valid():
         if request.POST['alloc_id'] == '-1':
+            form.data['alloc_id'] = -1
             return edit_event_display(
                 request,
                 opp,

--- a/expo/scheduler/views.py
+++ b/expo/scheduler/views.py
@@ -944,6 +944,7 @@ def edit_event_display(request, item, errorcontext=None):
             context.update(show_potential_workers(
                 item.as_subtype.volunteer_type,
                 item.start_time,
+                item.end_time,
                 item.eventitem.get_conference()))
         else:
             context.update(get_manage_opportunity_forms(item,

--- a/expo/scheduler/views.py
+++ b/expo/scheduler/views.py
@@ -447,6 +447,7 @@ def get_volunteer_info(opp, errorcontext=None):
 
     return {'eligible_volunteers': volunteer_set}
 
+
 @login_required
 def allocate_workers(request, opp_id):
     '''
@@ -460,7 +461,6 @@ def allocate_workers(request, opp_id):
 
     opp = get_object_or_404(Event, id=opp_id)
     form = WorkerAllocationForm(request.POST)
-
 
     if 'delete' in request.POST.keys():
         alloc = ResourceAllocation.objects.get(id=request.POST['alloc_id'])

--- a/expo/tests/contexts/volunteer_context.py
+++ b/expo/tests/contexts/volunteer_context.py
@@ -42,8 +42,8 @@ class VolunteerContext():
             volunteer=self.bid)
         self.opportunity = opportunity or GenericEventFactory(
             conference=self.conference,
-            type = 'Volunteer',
-            volunteer_type = self.interest.interest)
+            type='Volunteer',
+            volunteer_type=self.interest.interest)
         self.event = event or ShowFactory(
             conference=self.conference)
         self.role = role or "Volunteer"

--- a/expo/tests/contexts/volunteer_context.py
+++ b/expo/tests/contexts/volunteer_context.py
@@ -13,7 +13,10 @@ from tests.factories.scheduler_factories import (
     SchedEventFactory,
     WorkerFactory,
 )
-from datetime import date
+from datetime import (
+    date,
+    datetime,
+)
 
 
 class VolunteerContext():
@@ -35,19 +38,28 @@ class VolunteerContext():
             self.bid = VolunteerFactory(
                 conference=self.conference)
             self.profile = self.bid.profile
-        VolunteerInterestFactory(
+        self.interest = VolunteerInterestFactory(
             volunteer=self.bid)
-        self.opportunity = opportunity or GenericEventFactory()
-        self.event = event or ShowFactory()
+        self.opportunity = opportunity or GenericEventFactory(
+            conference=self.conference,
+            type = 'Volunteer',
+            volunteer_type = self.interest.interest)
+        self.event = event or ShowFactory(
+            conference=self.conference)
         self.role = role or "Volunteer"
         self.sched_event = SchedEventFactory(
-            eventitem=self.event.eventitem_ptr)
+            eventitem=self.event.eventitem_ptr,
+            starttime=datetime.combine(self.window.day.day,
+                                       self.window.start))
         self.opp_event = SchedEventFactory(
-            eventitem=self.opportunity.eventitem_ptr)
+            eventitem=self.opportunity.eventitem_ptr,
+            starttime=datetime.combine(self.window.day.day,
+                                       self.window.start),
+            max_volunteer=2)
         self.worker = WorkerFactory(_item=self.profile.workeritem,
                                     role=self.role)
         self.allocation = ResourceAllocationFactory(resource=self.worker,
-                                                    event=self.sched_event)
+                                                    event=self.opp_event)
         EventContainerFactory(parent_event=self.sched_event,
                               child_event=self.opp_event)
 

--- a/expo/tests/functions/scheduler_functions.py
+++ b/expo/tests/functions/scheduler_functions.py
@@ -67,3 +67,8 @@ def assert_selected(response, value, display):
         value,
         display)
     assert selection in response.content
+
+
+def assert_link(response, link):
+    selection = '<a href="%s">' % link
+    assert selection in response.content

--- a/expo/tests/scheduler/test_show_volunteer_info.py
+++ b/expo/tests/scheduler/test_show_volunteer_info.py
@@ -27,6 +27,8 @@ from gbe.models import AvailableInterest
 #    are covered elsewhere (ie, privileges and basic bad data)
 #
 '''
+
+
 class TestShowVolunteers(TestCase):
     view_name = 'edit_event'
 
@@ -47,13 +49,13 @@ class TestShowVolunteers(TestCase):
         context = StaffAreaContext()
         volunteer_opp = context.add_volunteer_opp()
         volunteer, alloc = context.book_volunteer(
-        volunteer_opp)
+            volunteer_opp)
         login_as(self.privileged_profile, self)
         response = self.client.get(
             reverse(
                 self.view_name,
                 args=["GenericEvent", volunteer_opp.pk],
-            urlconf="scheduler.urls"),
+                urlconf="scheduler.urls"),
             follow=True)
         assert ("no available volunteers" in response.content)
 

--- a/expo/tests/scheduler/test_show_volunteer_info.py
+++ b/expo/tests/scheduler/test_show_volunteer_info.py
@@ -1,0 +1,97 @@
+from django.core.urlresolvers import reverse
+import nose.tools as nt
+from django_nose.tools import assert_redirects
+from django.test import TestCase
+from django.test import Client
+from tests.factories.gbe_factories import (
+    ProfileFactory,
+)
+from tests.functions.gbe_functions import (
+    grant_privilege,
+    login_as,
+)
+from tests.functions.scheduler_functions import (
+    assert_link,
+)
+from tests.contexts import (
+    StaffAreaContext,
+    VolunteerContext,
+)
+from gbe.models import AvailableInterest
+
+'''
+#
+#  This is a spin off of edit event, or manage volunteer opportunities.
+#    It's the testing for the case of presenting eligible volunteers on an
+#    event that is a volunteer opportunity.  Not testing the basics, as they
+#    are covered elsewhere (ie, privileges and basic bad data)
+#
+'''
+class TestShowVolunteers(TestCase):
+    view_name = 'edit_event'
+
+    def setUp(self):
+        self.client = Client()
+        self.user = ProfileFactory.create().user_object
+        self.privileged_profile = ProfileFactory()
+        self.privileged_user = self.privileged_profile.user_object
+        grant_privilege(self.privileged_user, 'Volunteer Coordinator')
+        grant_privilege(self.privileged_user, 'Scheduling Mavens')
+        self.context = VolunteerContext()
+        self.url = reverse(
+            self.view_name,
+            args=["GenericEvent", self.context.opp_event.pk],
+            urlconf="scheduler.urls")
+
+    def test_no_available_volunteers(self):
+        context = StaffAreaContext()
+        volunteer_opp = context.add_volunteer_opp()
+        volunteer, alloc = context.book_volunteer(
+        volunteer_opp)
+        login_as(self.privileged_profile, self)
+        response = self.client.get(
+            reverse(
+                self.view_name,
+                args=["GenericEvent", volunteer_opp.pk],
+            urlconf="scheduler.urls"),
+            follow=True)
+        assert ("no available volunteers" in response.content)
+
+    def test_volunteer_has_conflict(self):
+        login_as(self.privileged_profile, self)
+        response = self.client.get(self.url, follow=True)
+        print response.content
+        assert ("no available volunteers" not in response.content)
+        assert_link(response, self.url)
+
+    def test_volunteer_is_available(self):
+        self.context.bid.available_windows.add(self.context.window)
+        login_as(self.privileged_profile, self)
+        response = self.client.get(self.url, follow=True)
+        assert ("no available volunteers" not in response.content)
+        assert('<td class="bid-table">Available</td>' in response.content)
+
+    def test_volunteer_is_not_available(self):
+        login_as(self.privileged_profile, self)
+        response = self.client.get(self.url, follow=True)
+        assert ("no available volunteers" not in response.content)
+        assert('<td class="bid-table">Not Available</td>' in response.content)
+
+    def test_volunteer_is_really_not_available(self):
+        self.context.bid.unavailable_windows.add(self.context.window)
+        login_as(self.privileged_profile, self)
+        response = self.client.get(self.url, follow=True)
+        assert ("no available volunteers" in response.content)
+
+    def test_volunteer_is_interested(self):
+        login_as(self.privileged_profile, self)
+        response = self.client.get(self.url, follow=True)
+        assert('4 - Somewhat interested' in response.content)
+
+    def test_volunteer_is_not(self):
+        self.context.interest.rank = 0
+        self.context.interest.save()
+        login_as(self.privileged_profile, self)
+        response = self.client.get(self.url, follow=True)
+        assert('4 - Somewhat interested' not in response.content)
+        assert ("no available volunteers" not in response.content)


### PR DESCRIPTION
Example for viewing (based on a database of data from live this year)

http://localhost:8282/scheduler/edit/GenericEvent/2306

If you’re working on data made by hand, to see the change you need to be working on a scheduled volunteer opportunity (meaning both a Generic Event and a scheduler.Event) with some # for max volunteer.

What you will see is a table at the bottom of the page labeled ‘Volunteers for (name of conference)’ that appears below the ‘Volunteer Allocation’ table.  If you don’t see the ‘Volunteer Allocation’ table - you are on the wrong page.

The new functionality should do everything in #655 plus, you can pick the role when assigning the volunteer, and you can go to the conflicting event (when there are conflicts) and edit the allocation there to remove conflicts.