### PR TITLE
GBE-908:  Selected caching disabled

### DIFF
--- a/expo/gbe/report_views.py
+++ b/expo/gbe/report_views.py
@@ -4,6 +4,7 @@ from django.http import HttpResponse, HttpResponseRedirect, Http404
 from django.core.urlresolvers import reverse
 from django.db.models import Q
 from django.core.management import call_command
+from django.views.decorators.cache import never_cache
 
 import gbe.models as conf
 import scheduler.models as sched
@@ -89,6 +90,7 @@ def staff_area(request, area_id):
                    'area': area})
 
 
+@never_cache
 def env_stuff(request, conference_choice=None):
     '''
     Generates an envelope-stuffing report.
@@ -178,6 +180,7 @@ def env_stuff(request, conference_choice=None):
     return response
 
 
+@never_cache
 def personal_schedule(request, profile_id='All'):
     viewer_profile = validate_perms(request, 'any', require=True)
 
@@ -377,6 +380,7 @@ def export_act_techinfo(request, show_id):
     return response
 
 
+@never_cache
 def room_schedule(request, room_id=None):
     viewer_profile = validate_perms(request,
                                     'any',
@@ -430,6 +434,7 @@ def room_schedule(request, room_id=None):
                    'conference': conference})
 
 
+@never_cache
 def room_setup(request):
 
     conference_slugs = conf.Conference.all_slugs()
@@ -483,6 +488,7 @@ def room_setup(request):
                    'conference': conference})
 
 
+@never_cache
 def export_badge_report(request, conference_choice=None):
     '''
     Export a csv of all badge printing details.

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.shortcuts import get_object_or_404
@@ -17,6 +18,7 @@ from gbe.models import Act
 
 @login_required
 @log_func
+@never_cache
 def ActChangeStateView(request, bid_id):
     '''
     Fairly specific to act - removes the act from all shows, and resets

--- a/expo/gbe/views/admin_profile_view.py
+++ b/expo/gbe/views/admin_profile_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect
 from django.shortcuts import (
@@ -16,6 +17,7 @@ from gbe.models import Profile
 
 @login_required
 @log_func
+@never_cache
 def AdminProfileView(request, profile_id):
     admin_profile = validate_perms(request, ('Registrar',))
     user_profile = get_object_or_404(Profile, resourceitem_id=profile_id)

--- a/expo/gbe/views/assign_volunteer_view.py
+++ b/expo/gbe/views/assign_volunteer_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.core.urlresolvers import reverse
 from django.shortcuts import (
@@ -16,6 +17,7 @@ from django.http import HttpResponseRedirect
 
 @login_required
 @log_func
+@never_cache
 def AssignVolunteerView(request, volunteer_id):
     '''
     Show a bid  which needs to be assigned to shifts by the coordinator.

--- a/expo/gbe/views/bid_changestate_view.py
+++ b/expo/gbe/views/bid_changestate_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import (
     get_object_or_404,
@@ -13,6 +14,7 @@ from gbe.forms import BidStateChangeForm
 
 @login_required
 @log_func
+@never_cache
 def BidChangeStateView(request, bid_id, redirectURL):
     '''
     The generic function to change a bid to a new state (accepted,

--- a/expo/gbe/views/class_changestate_view.py
+++ b/expo/gbe/views/class_changestate_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from expo.gbe_logging import log_func
 from django.shortcuts import get_object_or_404
@@ -9,6 +10,7 @@ from gbe.models import Class
 
 @login_required
 @log_func
+@never_cache
 def ClassChangeStateView(request, bid_id):
     '''
     Because classes are scheduleable, if a class is rejected, or

--- a/expo/gbe/views/costume_changestate_view.py
+++ b/expo/gbe/views/costume_changestate_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from expo.gbe_logging import log_func
 
@@ -7,6 +8,7 @@ from gbe.views import BidChangeStateView
 
 @login_required
 @log_func
+@never_cache
 def CostumeChangeStateView(request, bid_id):
     reviewer = validate_perms(request, ('Costume Coordinator',))
     return BidChangeStateView(request, bid_id, 'costume_review_list')

--- a/expo/gbe/views/edit_act_techinfo_view.py
+++ b/expo/gbe/views/edit_act_techinfo_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -81,6 +82,7 @@ def set_rehearsal_forms(shows, act):
 
 @login_required
 @log_func
+@never_cache
 def EditActTechInfoView(request, act_id):
     '''
     Modify tech info for an existing act
@@ -128,7 +130,8 @@ def EditActTechInfoView(request, act_id):
                                           id=request.POST['rehearsal'])
             show = get_object_or_404(
                 Show,
-                title=request.POST['show']).scheduler_events.first()
+                title=request.POST['show'],
+                conference=act.conference).scheduler_events.first()
             act.set_rehearsal(show, rehearsal)
         audioform = AudioInfoSubmitForm(request.POST,
                                         request.FILES,

--- a/expo/gbe/views/edit_act_techinfo_view.py
+++ b/expo/gbe/views/edit_act_techinfo_view.py
@@ -130,8 +130,7 @@ def EditActTechInfoView(request, act_id):
                                           id=request.POST['rehearsal'])
             show = get_object_or_404(
                 Show,
-                title=request.POST['show'],
-                conference=act.conference).scheduler_events.first()
+                title=request.POST['show']).scheduler_events.first()
             act.set_rehearsal(show, rehearsal)
         audioform = AudioInfoSubmitForm(request.POST,
                                         request.FILES,

--- a/expo/gbe/views/edit_act_view.py
+++ b/expo/gbe/views/edit_act_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.core.urlresolvers import reverse
@@ -36,6 +37,7 @@ from gbetext import (
 from gbe.views.act_display_functions import display_invalid_act
 
 
+@never_cache
 @login_required
 @log_func
 def EditActView(request, act_id):

--- a/expo/gbe/views/edit_class_view.py
+++ b/expo/gbe/views/edit_class_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import (
@@ -29,6 +30,7 @@ from gbetext import (
 
 @login_required
 @log_func
+@never_cache
 def EditClassView(request, class_id):
     '''
     Edit an existing class.

--- a/expo/gbe/views/edit_costume_view.py
+++ b/expo/gbe/views/edit_costume_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.shortcuts import (
@@ -34,6 +35,7 @@ from gbetext import (
 
 @login_required
 @log_func
+@never_cache
 def EditCostumeView(request, costume_id):
     '''
     Edit an existing costume display proposal.

--- a/expo/gbe/views/edit_persona_view.py
+++ b/expo/gbe/views/edit_persona_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -18,6 +19,7 @@ from gbe.models import UserMessage
 
 @login_required
 @log_func
+@never_cache
 def EditPersonaView(request, persona_id):
     '''
     Modify an existing Persona object.

--- a/expo/gbe/views/edit_troupe_view.py
+++ b/expo/gbe/views/edit_troupe_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -24,6 +25,7 @@ from gbetext import default_edit_troupe_msg
 
 @login_required
 @log_func
+@never_cache
 def EditTroupeView(request, troupe_id=None):
     page_title = 'Manage Troupe'
     view_title = 'Tell Us About Your Troupe'

--- a/expo/gbe/views/edit_vendor_view.py
+++ b/expo/gbe/views/edit_vendor_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.shortcuts import (
@@ -28,6 +29,7 @@ from gbetext import (
 
 @login_required
 @log_func
+@never_cache
 def EditVendorView(request, vendor_id):
     page_title = 'Edit Vendor Application'
     view_title = 'Edit Your Vendor Application'

--- a/expo/gbe/views/edit_volunteer_view.py
+++ b/expo/gbe/views/edit_volunteer_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.shortcuts import (
@@ -27,6 +28,7 @@ from gbe.views.volunteer_display_functions import (
 
 @login_required
 @log_func
+@never_cache
 def EditVolunteerView(request, volunteer_id):
     page_title = "Edit Volunteer Bid"
     view_title = "Edit Submitted Volunteer Bid"

--- a/expo/gbe/views/landing_page_view.py
+++ b/expo/gbe/views/landing_page_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404
 from django.template import (
@@ -27,6 +28,7 @@ from expo.gbe_logging import log_func
 
 @login_required
 @log_func
+@never_cache
 def LandingPageView(request, profile_id=None, historical=False):
     historical = "historical" in request.GET.keys()
     standard_context = {}

--- a/expo/gbe/views/profile_view.py
+++ b/expo/gbe/views/profile_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from expo.gbe_logging import log_func
 from django.shortcuts import (
     get_object_or_404,
@@ -8,6 +9,7 @@ from gbe.models import Profile
 
 
 @log_func
+@never_cache
 def ProfileView(request, profile_id=None):
     '''
     Display a profile. Display depends on user. If own profile, show

--- a/expo/gbe/views/review_bid_list_view.py
+++ b/expo/gbe/views/review_bid_list_view.py
@@ -1,4 +1,5 @@
 from django.views.generic import View
+from django.views.decorators.cache import never_cache
 from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect
@@ -59,6 +60,7 @@ class ReviewBidListView(View):
         review_query = self.review_query(bids)
         self.rows = self.get_rows(bids, review_query)
 
+    @never_cache
     def get(self, request, *args, **kwargs):
         reviewer = validate_perms(request, self.reviewer_permissions)
         self.user = request.user

--- a/expo/gbe/views/review_bid_view.py
+++ b/expo/gbe/views/review_bid_view.py
@@ -1,4 +1,5 @@
 from django.views.generic import View
+from django.views.decorators.cache import never_cache
 from django.utils.decorators import method_decorator
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import (
@@ -96,12 +97,14 @@ class ReviewBidView(View):
             self.bid_eval = self.bid_evaluation_type(
                 evaluator=self.reviewer, bid=self.object)
 
+    @never_cache
     def get(self, request, *args, **kwargs):
         self.groundwork(request, args, kwargs)
         self.form = self.bid_evaluation_form_type(instance=self.bid_eval)
         return (self.object_not_current_redirect() or
                 self.bid_review_response(request))
 
+    @never_cache
     def post(self, request, *args, **kwargs):
         self.groundwork(request, args, kwargs)
         self.form = self.bid_evaluation_form_type(request.POST,

--- a/expo/gbe/views/review_profiles_view.py
+++ b/expo/gbe/views/review_profiles_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from django.core.urlresolvers import reverse
@@ -9,6 +10,7 @@ from gbe.functions import validate_perms
 
 @login_required
 @log_func
+@never_cache
 def ReviewProfilesView(request):
     admin_profile = validate_perms(request, ('Registrar',
                                              'Volunteer Coordinator',

--- a/expo/gbe/views/update_profile_view.py
+++ b/expo/gbe/views/update_profile_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from django.contrib import messages
 from django.http import HttpResponseRedirect
@@ -19,6 +20,7 @@ from gbetext import default_update_profile_msg
 
 @login_required
 @log_func
+@never_cache
 def UpdateProfileView(request):
     profile = validate_profile(request, require=False)
     if not profile:

--- a/expo/gbe/views/vendor_changestate_view.py
+++ b/expo/gbe/views/vendor_changestate_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from expo.gbe_logging import log_func
 
@@ -7,6 +8,7 @@ from gbe.views import BidChangeStateView
 
 @login_required
 @log_func
+@never_cache
 def VendorChangeStateView(request, bid_id):
     '''
     The generic function to change a bid to a new state (accepted,

--- a/expo/gbe/views/volunteer_changestate_view.py
+++ b/expo/gbe/views/volunteer_changestate_view.py
@@ -1,3 +1,4 @@
+from django.views.decorators.cache import never_cache
 from django.contrib.auth.decorators import login_required
 from expo.gbe_logging import log_func
 from django.shortcuts import (
@@ -16,6 +17,7 @@ from django.contrib import messages
 
 @login_required
 @log_func
+@never_cache
 def VolunteerChangeStateView(request, bid_id):
     '''
     Fairly specific to volunteer - removes the profile from all volunteer

--- a/expo/scheduler/views.py
+++ b/expo/scheduler/views.py
@@ -25,6 +25,7 @@ from django.contrib.auth import (
     logout,
     authenticate,
 )
+from django.views.decorators.cache import never_cache
 from django.forms.models import inlineformset_factory
 from django.core.urlresolvers import reverse
 from datetime import datetime
@@ -164,6 +165,7 @@ def get_event_display_info(eventitem_id):
 
 
 @login_required
+@never_cache
 def event_list(request, event_type=''):
     '''
     List of events (all, or by type)
@@ -222,6 +224,7 @@ def detail_view(request, eventitem_id):
 
 
 @login_required
+@never_cache
 def schedule_acts(request, show_title=None):
     '''
     Display a list of acts available for scheduling, allows setting show/order
@@ -421,6 +424,7 @@ def get_worker_allocation_forms(opp, errorcontext=None):
 
 
 @login_required
+@never_cache
 def allocate_workers(request, opp_id):
     '''
     Process a worker allocation form
@@ -479,6 +483,7 @@ def allocate_workers(request, opp_id):
 
 
 @login_required
+@never_cache
 def manage_volunteer_opportunities(request, event_id):
     '''
     Create or edit volunteer opportunities for an event.
@@ -574,6 +579,7 @@ def manage_volunteer_opportunities(request, event_id):
 
 
 @login_required
+@never_cache
 def contact_info(request,
                  event_id,
                  resource_type='All',
@@ -723,6 +729,7 @@ def contact_vendors(conference):
 
 
 @login_required
+@never_cache
 def contact_by_role(request, participant_type):
     validate_perms(request, "any", require=True)
     conference = get_current_conference()
@@ -780,6 +787,7 @@ def set_multi_role(event, data, roles=None):
 
 
 @login_required
+@never_cache
 def add_event(request, eventitem_id, event_type='Class'):
     '''
     Add an item to the conference schedule and/or set its schedule details
@@ -846,6 +854,7 @@ def add_event(request, eventitem_id, event_type='Class'):
 
 
 @login_required
+@never_cache
 def edit_event(request, scheduler_event_id, event_type='class'):
     '''
     Add an item to the conference schedule and/or set its schedule details


### PR DESCRIPTION
I’ve disabled caching from:

- all edit bid pages
- all review bid list display pages
- all voting and change state action pages (so that you can see what you voted or changed most recently when reloading)
- profile management - both for admin and regular users
- the landing page for a logged in user
- volunteer assignment
- scheduler views - the privileged areas - event edit, the event editing list displays, act scheduling, contact email lists 
- reports that are focused on print runs, vs. regular reviews

The following will still have a 10 minute cache:
- pages that are primarily for static public view (event details, event view-only lists, fashion fair, show/act displays)
- pages with no user-made data (submit for the first time pages - like create bids, create profiles, etc)
- pages that are static that staff download way more than they change (some of the reports).

The marker used consistently is @never_cache, which is documented here:

https://docs.djangoproject.com/en/1.7/topics/cache/#the-per-site-cache

For a test:
- make sure you’ve got no cache setup in your local (DummyCache turns off all caching)
- use Review Acts
- cast a vote
- verify that the vote is updated on the review act list
- verify that the vote is updated on the “review” link for the act you submitted.

That’s an example, for each @never_cache you could do the same kind of test for each thread.

I did that manually, as caching doesn’t seem to apply to unit tests.

Unit tests and pepdiff remain in a good state.