### PR TITLE
GBE 699: clean up volunteer review

### DIFF
--- a/expo/gbe/views/volunteer_display_functions.py
+++ b/expo/gbe/views/volunteer_display_functions.py
@@ -50,7 +50,7 @@ def get_volunteer_forms(volunteer):
                  'first_name': volunteer.profile.user_object.first_name,
                  'last_name': volunteer.profile.user_object.last_name},
         prefix='Contact Info')
-    
+
     participantform.fields['state'] = MultipleChoiceField(
         choices=[(volunteer.profile.state,
                   dict(states_options)[volunteer.profile.state])],

--- a/expo/tests/gbe/test_review_volunteer.py
+++ b/expo/tests/gbe/test_review_volunteer.py
@@ -21,6 +21,7 @@ from tests.contexts.volunteer_context import VolunteerContext
 from gbe.models import Volunteer
 from gbetext import states_options
 
+
 class TestReviewVolunteer(TestCase):
     '''Tests for review_volunteer view'''
     view_name = 'volunteer_review'
@@ -205,7 +206,8 @@ class TestReviewVolunteer(TestCase):
         login_as(self.privileged_user, self)
         response = self.client.get(url)
         state_dict = dict(states_options)
-        self.assertTrue(state_dict[volunteer.profile.state] in response.content)
+        self.assertTrue(
+            state_dict[volunteer.profile.state] in response.content)
         self.assertTrue(state_dict["CA"] not in response.content)
 
     def test_review_volunteer_clean_how_heard(self):

--- a/expo/tests/gbe/test_review_volunteer.py
+++ b/expo/tests/gbe/test_review_volunteer.py
@@ -17,8 +17,9 @@ from tests.functions.gbe_functions import (
     is_login_page,
     login_as,
 )
+from tests.contexts.volunteer_context import VolunteerContext
 from gbe.models import Volunteer
-
+from gbetext import states_options
 
 class TestReviewVolunteer(TestCase):
     '''Tests for review_volunteer view'''
@@ -166,3 +167,55 @@ class TestReviewVolunteer(TestCase):
         login_as(self.privileged_user, self)
         response = self.client.get(url)
         assert_interest_view(response, interest)
+
+    def test_review_volunteer_clean_available_windows(self):
+        context = VolunteerContext()
+        context.bid.available_windows.add(context.window)
+        context.bid.save()
+        not_there = context.add_window()
+        url = reverse(self.view_name,
+                      args=[context.bid.pk],
+                      urlconf='gbe.urls')
+
+        login_as(self.privileged_user, self)
+        response = self.client.get(url)
+        self.assertTrue(str(context.window) in response.content)
+        self.assertTrue(str(not_there) not in response.content)
+
+    def test_review_volunteer_clean_unavailable_windows(self):
+        context = VolunteerContext()
+        context.bid.unavailable_windows.add(context.window)
+        context.bid.save()
+        not_there = context.add_window()
+        url = reverse(self.view_name,
+                      args=[context.bid.pk],
+                      urlconf='gbe.urls')
+
+        login_as(self.privileged_user, self)
+        response = self.client.get(url)
+        self.assertTrue(str(context.window) in response.content)
+        self.assertTrue(str(not_there) not in response.content)
+
+    def test_review_volunteer_clean_state(self):
+        volunteer = VolunteerFactory()
+        url = reverse(self.view_name,
+                      args=[volunteer.pk],
+                      urlconf='gbe.urls')
+
+        login_as(self.privileged_user, self)
+        response = self.client.get(url)
+        state_dict = dict(states_options)
+        self.assertTrue(state_dict[volunteer.profile.state] in response.content)
+        self.assertTrue(state_dict["CA"] not in response.content)
+
+    def test_review_volunteer_clean_how_heard(self):
+        profile = ProfileFactory(how_heard=['Word of mouth'])
+        volunteer = VolunteerFactory(profile=profile)
+        url = reverse(self.view_name,
+                      args=[volunteer.pk],
+                      urlconf='gbe.urls')
+
+        login_as(self.privileged_user, self)
+        response = self.client.get(url)
+        self.assertTrue(profile.how_heard[0] in response.content)
+        self.assertTrue("Attended Previously" not in response.content)


### PR DESCRIPTION
Did as we spoke about last scrum:
- updated volunteer display to show only the chosen available time slots, unavailable time slots, state, and how heard selections.

As a side benefit of refactoring, the same code covers review volunteers (http://localhost:8282/volunteer/review/640) and view volunteer (http://localhost:8282/volunteer/view/640) so now both are clean.

Made a unit test set (4 tests) for the four things I changed, both positive and negative cases.