### PR TITLE
GBE-678: Add a link to schedule Acts for the given show on the act tect info report.

### DIFF
--- a/expo/gbe/report_views.py
+++ b/expo/gbe/report_views.py
@@ -224,7 +224,7 @@ def review_act_techinfo(request, show_id=None):
     # using try not get_or_404 to cover the case where the show is there
     # but does not have any scheduled events.
     # I can still show a list of shows this way.
-    
+
     scheduling_link = ''
 
     show = None

--- a/expo/gbe/report_views.py
+++ b/expo/gbe/report_views.py
@@ -215,6 +215,7 @@ def personal_schedule(request, profile_id='All'):
                    'conference': conference})
 
 
+@never_cache
 def review_act_techinfo(request, show_id=None):
     '''
     Show the list of act tech info for all acts in a given show
@@ -225,10 +226,6 @@ def review_act_techinfo(request, show_id=None):
     # I can still show a list of shows this way.
     
     scheduling_link = ''
-    if validate_perms(request, ('Scheduling Mavens',), require=False):
-        scheduling_link = reverse('schedule_acts',
-                urlconf='scheduler.urls',
-                args=[show_id])
 
     show = None
     acts = []
@@ -238,6 +235,13 @@ def review_act_techinfo(request, show_id=None):
             show = conf.Show.objects.get(eventitem_id=show_id)
             acts = show.scheduler_events.first().get_acts(status=3)
             acts = sorted(acts, key=lambda act: act.order)
+            if validate_perms(
+                    request, ('Scheduling Mavens',), require=False):
+                scheduling_link = reverse(
+                    'schedule_acts',
+                    urlconf='scheduler.urls',
+                    args=[show.pk])
+
         except:
             logger.error("review_act_techinfo: Invalid show id")
             pass

--- a/expo/gbe/report_views.py
+++ b/expo/gbe/report_views.py
@@ -223,6 +223,12 @@ def review_act_techinfo(request, show_id=None):
     # using try not get_or_404 to cover the case where the show is there
     # but does not have any scheduled events.
     # I can still show a list of shows this way.
+    
+    scheduling_link = ''
+    if validate_perms(request, ('Scheduling Mavens',), require=False):
+        scheduling_link = reverse('schedule_acts',
+                urlconf='scheduler.urls',
+                args=[show_id])
 
     show = None
     acts = []
@@ -248,8 +254,9 @@ def review_act_techinfo(request, show_id=None):
                        conference=conference),
                    'conference_slugs': conference_slugs(),
                    'conference': conference,
+                   'scheduling_link': scheduling_link,
                    'return_link': reverse('act_techinfo_review',
-                                          urlconf='gbe.report_urls')})
+                                          urlconf='gbe.report_urls',)})
 
 
 def download_tracks_for_show(request, show_id):

--- a/expo/gbe/templates/gbe/report/act_tech_review.tmpl
+++ b/expo/gbe/templates/gbe/report/act_tech_review.tmpl
@@ -24,7 +24,7 @@
   
   {% if scheduling_link and scheduling_link|length > 0 %}
     </br></br>
-    <a href='{{scheduling_link}}'>Schedule Acts for this Show</a>
+    <a href="{{scheduling_link}}">Schedule Acts for this Show</a>
   {% endif %}
 <br><br>
 <span class="error_row">Highlighted text</span> reflects incomplete acts.<br>

--- a/expo/gbe/templates/gbe/report/act_tech_review.tmpl
+++ b/expo/gbe/templates/gbe/report/act_tech_review.tmpl
@@ -21,6 +21,11 @@
     <a href="{% url 'reporting:act_techinfo_review' show.eventitem_id%}">{{show}}</a>
     {% if not forloop.last %} | {% endif %}
   {% endfor %}
+  
+  {% if scheduling_link and scheduling_link|length > 0 %}
+    </br></br>
+    <a href='{{scheduling_link}}'>Schedule Acts for this Show</a>
+  {% endif %}
 <br><br>
 <span class="error_row">Highlighted text</span> reflects incomplete acts.<br>
 

--- a/expo/tests/gbe/test_reports.py
+++ b/expo/tests/gbe/test_reports.py
@@ -311,7 +311,6 @@ class TestReports(TestCase):
             msg="Can't find table header")
         self.assertNotContains(response, 'Schedule Acts for this Show')
 
-
     def test_review_act_techinfo_has_link_for_scheduler(self):
         '''review_act_techinfo view should show schedule acts if user
             has the right privilege
@@ -335,7 +334,6 @@ class TestReports(TestCase):
             urlconf='scheduler.urls',
             args=[curr_show.pk]))
         self.assertContains(response, 'Schedule Acts for this Show')
-
 
     def test_review_act_techinfo_with_conference_slug(self):
         '''review_act_techinfo view show correct events for slug


### PR DESCRIPTION
Test;

- if you have BOTH ‘Tech Crew’ and ‘Schedule Mavens’ - then:

- on 

http://localhost:8282/reports/acttechinfo/view_summary/545

you will see “Schedule Acts for this Show” 

This will take you to:

http://localhost:8282/scheduler/acts/532

With the show I’ve referenced, there are no currently scheduled acts in our test data… but if you pick a show from an older conference, you’ll also see a table of information on each page (the table works differently between the pages).
