### PR TITLE
GBE 933: Throw error when user tries to submit same time slot as unavailable and available.

### DIFF
--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -400,9 +400,11 @@ class VolunteerBidForm(forms.ModelForm):
             self.cleaned_data['unavailable_windows'])
         if len(conflict_windows) > 0:
             windows = ", ".join(str(w) for w in conflict_windows)
-            message = "Availability time conflict - the following times " + \
-                 "can't be available and not available: %s" % windows
-            raise ValidationError(message)
+            self._errors['available_windows'] = \
+                'Available times conflict with unavailable times.  ' + \
+                'Conflicts are: %s' % windows
+            self._errors['unavailable_windows'] = \
+                'Unavailable times conflict with Available times.'
         return cleaned_data
 
     class Meta:

--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -395,9 +395,12 @@ class VolunteerBidForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super(VolunteerBidForm, self).clean()
-        conflict_windows = set(
-            self.cleaned_data['available_windows']).intersection(
-            self.cleaned_data['unavailable_windows'])
+        conflict_windows = []
+        if ('available_windows' in self.cleaned_data) and (
+                'unavailable_windows' in self.cleaned_data):
+            conflict_windows = set(
+                self.cleaned_data['available_windows']).intersection(
+                self.cleaned_data['unavailable_windows'])
         if len(conflict_windows) > 0:
             windows = ", ".join(str(w) for w in conflict_windows)
             self._errors['available_windows'] = \

--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -393,6 +393,18 @@ class VolunteerBidForm(forms.ModelForm):
         self.fields['available_windows'].queryset = available_windows
         self.fields['unavailable_windows'].queryset = unavailable_windows
 
+    def clean(self):
+        cleaned_data = super(VolunteerBidForm, self).clean()
+        conflict_windows = set(
+            self.cleaned_data['available_windows']).intersection(
+            self.cleaned_data['unavailable_windows'])
+        if len(conflict_windows) > 0:
+            windows = ", ".join(str(w) for w in conflict_windows)
+            message = "Availability time conflict - the following times " + \
+                 "can't be available and not available: %s" % windows
+            raise ValidationError(message)
+        return cleaned_data
+
     class Meta:
         model = Volunteer
         fields = ['number_shifts',

--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -401,10 +401,9 @@ class VolunteerBidForm(forms.ModelForm):
         if len(conflict_windows) > 0:
             windows = ", ".join(str(w) for w in conflict_windows)
             self._errors['available_windows'] = \
-                'Available times conflict with unavailable times.  ' + \
-                'Conflicts are: %s' % windows
+                volunteer_available_time_conflict % windows
             self._errors['unavailable_windows'] = \
-                'Unavailable times conflict with Available times.'
+                volunteer_unavailable_time_conflict
         return cleaned_data
 
     class Meta:

--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -383,12 +383,8 @@ class VolunteerBidForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         if 'available_windows' in kwargs:
             available_windows = kwargs.pop('available_windows')
-        else:
-            available_windows = None
         if 'unavailable_windows' in kwargs:
             unavailable_windows = kwargs.pop('unavailable_windows')
-        else:
-            unavailable_windows = None
         super(VolunteerBidForm, self).__init__(*args, **kwargs)
         self.fields['available_windows'].queryset = available_windows
         self.fields['unavailable_windows'].queryset = unavailable_windows

--- a/expo/gbe/templates/gbe/bid.tmpl
+++ b/expo/gbe/templates/gbe/bid.tmpl
@@ -7,10 +7,11 @@
 {% block content %}
 <h2 class="subtitle">{{view_title}}</h2>
 <p>{{view_header_text | safe}}
+{% for form in forms %}
   {% if form.errors %}
     <p style= "color:red"> There is an error on the form.  </p>
-
   {% endif %}
+{% endfor %}
   {% if errors %}
     {% for error in errors %}
     <p style= "color:red">{{error}}</p>

--- a/expo/gbe_forms_text.py
+++ b/expo/gbe_forms_text.py
@@ -149,6 +149,12 @@ volunteer_help_texts = {
     in the box below.')
 }
 
+volunteer_available_time_conflict = \
+    'Available times conflict with unavailable times.  Conflicts are: %s'
+
+volunteer_unavailable_time_conflict = \
+    'Unavailable times conflict with Available times.'
+
 phone_error1 = ['Phone number needed here']
 phone_error2 = ['... or here ']
 phone_error3 = ['...or choose a contact method that does not require a phone.']

--- a/expo/tests/gbe/test_create_volunteer.py
+++ b/expo/tests/gbe/test_create_volunteer.py
@@ -22,6 +22,7 @@ from gbetext import (
     default_volunteer_no_bid_msg,
     default_volunteer_no_interest_msg
 )
+from gbe_forms_text import volunteer_unavailable_time_conflict
 from gbe.models import (
     AvailableInterest,
     Conference,
@@ -223,3 +224,9 @@ class TestCreateVolunteer(TestCase):
         self.assertEqual(response.status_code, 200)
         assert_alert_exists(
             response, 'danger', 'Error', msg.description)
+
+    def test_volunteer_time_conflict_checked(self):
+        data = self.get_volunteer_form()
+        data['available_windows'] = data['unavailable_windows']
+        response, data = self.post_volunteer_submission(data=data)
+        assert volunteer_unavailable_time_conflict in response.content


### PR DESCRIPTION
- put a check in Volunteer Bid form to prevent this.
- it will throw an error for both the available field (with details) and the unavailable field
- found that the top of the form did not give an error, so fixed the code that used to throw this alert
- found some dead code and removed it in this area.

———————

to test:
- seed your database with current data or make a conference that has volunteer windows in it.
- try to submit a volunteer bid (/volunteer/bid) with the same time slot marked for available and unavailable.
- see it give you errors.

The same thing will happen for volunteer editing (volunteer coordinators can edit a volunteer bid on the review volunteers page - there is an option for ‘edit’)
