### PR TITLE
GBE-763: Add creator to required draft fields.

### DIFF
--- a/expo/gbe/models/remains.py
+++ b/expo/gbe/models/remains.py
@@ -836,7 +836,7 @@ class Costume(Biddable):
 
     @property
     def bid_draft_fields(self):
-        return (['title'])
+        return (['title', 'creator'])
 
     @property
     def bid_review_header(self):


### PR DESCRIPTION
This is a one line change - test by;
- on master: go to http://localhost:8282/costume/create

- see that Costume Creator has a * but is not bold.

- on this branch - go to the same place.

- It is now bold.

The display is controlled by a switch in models - I just made sure it had the right value.  Anything required for the draft should be in bid_draft_fields.