### PR TITLE
GBE-856: show only video selection

### DIFF
--- a/expo/gbe/views/act_display_functions.py
+++ b/expo/gbe/views/act_display_functions.py
@@ -1,6 +1,9 @@
 from django.contrib import messages
 from django.core.urlresolvers import reverse
 from django.shortcuts import render
+from django.forms import (
+    ChoiceField,
+)
 from gbe.models import (
     Act,
     UserMessage,
@@ -9,6 +12,8 @@ from gbetext import (
     default_act_title_conflict,
     act_not_unique,
 )
+from gbe_forms_text import act_bid_labels
+from gbe.forms import ActEditForm
 
 
 def display_invalid_act(request, data, form, conference, profile, view):
@@ -44,3 +49,25 @@ def display_invalid_act(request, data, form, conference, profile, view):
         'gbe/bid.tmpl',
         data
     )
+
+
+def get_act_form(act):
+    audio_info = act.tech.audio
+    stage_info = act.tech.stage
+    initial = {
+        'track_title': audio_info.track_title,
+        'track_artist': audio_info.track_artist,
+        'track_duration': audio_info.track_duration,
+        'act_duration': stage_info.act_duration
+    }
+
+    act_form = ActEditForm(
+        instance=act,
+        prefix="The Act",
+        initial=initial)
+    act_form.fields['video_choice'] = ChoiceField(
+            choices=[(act.video_choice,
+                      act.get_video_choice_display())],
+            label=act_bid_labels['video_choice'])
+
+    return act_form

--- a/expo/gbe/views/review_act_view.py
+++ b/expo/gbe/views/review_act_view.py
@@ -13,6 +13,7 @@ from gbe.views import ReviewBidView
 from gbe.views.functions import get_performer_form
 from gbe.views.act_display_functions import get_act_form
 
+
 class ReviewActView(ReviewBidView):
     '''
     Show a bid  which needs to be reviewed by the current user.

--- a/expo/gbe/views/review_act_view.py
+++ b/expo/gbe/views/review_act_view.py
@@ -7,12 +7,11 @@ from gbe.models import (
 )
 from gbe.forms import (
     ActBidEvaluationForm,
-    ActEditForm,
     BidStateChangeForm,
 )
 from gbe.views import ReviewBidView
 from gbe.views.functions import get_performer_form
-
+from gbe.views.act_display_functions import get_act_form
 
 class ReviewActView(ReviewBidView):
     '''
@@ -22,9 +21,6 @@ class ReviewActView(ReviewBidView):
     '''
     reviewer_permissions = ('Act Reviewers', )
     coordinator_permissions = ('Act Coordinator',)
-    bid_prefix = "The Act"
-    bidder_prefix = "The Performer(s)"
-    bid_form_type = ActEditForm
     object_type = Act
     review_list_view_name = 'act_review_list'
     bid_view_name = 'act_view'
@@ -35,16 +31,7 @@ class ReviewActView(ReviewBidView):
     def groundwork(self, request, args, kwargs):
         super(ReviewActView, self).groundwork(request, args, kwargs)
         self.bidder = get_performer_form(self.object.performer)
-
-        audio_info = self.object.tech.audio
-        stage_info = self.object.tech.stage
-        initial = {
-            'track_title': audio_info.track_title,
-            'track_artist': audio_info.track_artist,
-            'track_duration': audio_info.track_duration,
-            'act_duration': stage_info.act_duration
-        }
-        self.create_object_form(initial=initial)
+        self.object_form = get_act_form(self.object)
         self.readonlyform_pieces = [self.object_form, self.bidder]
 
     def create_action_form(self, act):

--- a/expo/gbe/views/view_act_view.py
+++ b/expo/gbe/views/view_act_view.py
@@ -6,6 +6,7 @@ from gbe.models import (
 )
 from gbe.views import ViewBidView
 from gbe.views.functions import get_performer_form
+from gbe.views.act_display_functions import get_act_form
 
 class ViewActView(ViewBidView):
 
@@ -18,16 +19,7 @@ class ViewActView(ViewBidView):
         return self.bid.performer.contact
 
     def get_display_forms(self):
-        audio_info = self.bid.tech.audio
-        stage_info = self.bid.tech.stage
-        actform = self.object_form_type(
-            instance=self.bid,
-            prefix=self.bid_prefix,
-            initial={'track_title': audio_info.track_title,
-                     'track_artist': audio_info.track_artist,
-                     'track_duration': audio_info.track_duration,
-                     'act_duration': stage_info.act_duration}
-        )
+        actform = get_act_form(self.bid)
 
         performer_form = get_performer_form(self.bid.performer)
         return (actform, performer_form)

--- a/expo/gbe/views/view_act_view.py
+++ b/expo/gbe/views/view_act_view.py
@@ -8,6 +8,7 @@ from gbe.views import ViewBidView
 from gbe.views.functions import get_performer_form
 from gbe.views.act_display_functions import get_act_form
 
+
 class ViewActView(ViewBidView):
 
     bid_type = Act

--- a/expo/tests/gbe/test_review_act.py
+++ b/expo/tests/gbe/test_review_act.py
@@ -21,7 +21,7 @@ from tests.functions.gbe_functions import (
 )
 from tests.functions.scheduler_functions import assert_selected
 from gbe.models import ActBidEvaluation
-
+from gbetext import video_options
 
 class TestReviewAct(TestCase):
     '''Tests for review_act view'''
@@ -211,3 +211,13 @@ class TestReviewAct(TestCase):
         self.assertTrue(len(evals), 1)
         self.assertTrue(evals[0].secondary_vote.vote, 1)
         self.assertTrue(evals[0].primary_vote.show, show)
+
+    def test_video_choice_display(self):
+        act = ActFactory()
+        url = reverse('act_review',
+                      urlconf='gbe.urls',
+                      args=[act.pk])
+        login_as(self.privileged_user, self)
+        response = self.client.get(url)
+        assert 'Video Notes:' in response.content
+        assert video_options[1][1] not in response.content

--- a/expo/tests/gbe/test_review_act.py
+++ b/expo/tests/gbe/test_review_act.py
@@ -23,6 +23,7 @@ from tests.functions.scheduler_functions import assert_selected
 from gbe.models import ActBidEvaluation
 from gbetext import video_options
 
+
 class TestReviewAct(TestCase):
     '''Tests for review_act view'''
 


### PR DESCRIPTION
addresses #856 using the same trick used on other tickets - overload the form with only the choice that was selected.

Since the bug affects both ‘view’ and ‘review’ - I refactored them both to use a shared function.