### PR TITLE
GBE 546: remove hard coded dates

### DIFF
--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -44,13 +44,18 @@ from gbe.expoformfields import (
     DurationFormField,
     FriendlyURLInput,
 )
-from scheduler.functions import (
-    conference_days,
-    conference_times,
-)
 from gbe.functions import get_current_conference
 from django.shortcuts import get_object_or_404
 from django.core.exceptions import ValidationError
+from django.utils.formats import date_format
+
+time_start = 8 * 60
+time_stop = 24 * 60
+
+conference_times = [(time(mins / 60, mins % 60),
+                     date_format(time(mins / 60, mins % 60),
+                                 "TIME_FORMAT"))
+                    for mins in range(time_start, time_stop, 30)]
 
 
 class ParticipantForm(forms.ModelForm):

--- a/expo/scheduler/forms.py
+++ b/expo/scheduler/forms.py
@@ -12,13 +12,6 @@ import gbe.models as conf
 from gbe.functions import get_current_conference
 import pytz
 
-conference_days = (
-    (date_format(datetime(2016, 02, 4), "DAY_FORMAT"), 'Thursday'),
-    (date_format(datetime(2016, 02, 5), "DAY_FORMAT"), 'Friday'),
-    (date_format(datetime(2016, 02, 6), "DAY_FORMAT"), 'Saturday'),
-    (date_format(datetime(2016, 02, 7), "DAY_FORMAT"), 'Sunday'),
-)
-
 
 time_start = 8 * 60
 time_stop = 24 * 60

--- a/expo/scheduler/functions.py
+++ b/expo/scheduler/functions.py
@@ -24,38 +24,8 @@ from django.utils.formats import date_format
 from django.core.urlresolvers import reverse
 import pytz
 
-conference_days = (
-    (date_format(datetime(2015, 02, 19), "DAY_FORMAT"), 'Thursday'),
-    (date_format(datetime(2015, 02, 20), "DAY_FORMAT"), 'Friday'),
-    (date_format(datetime(2015, 02, 21), "DAY_FORMAT"), 'Saturday'),
-    (date_format(datetime(2015, 02, 22), "DAY_FORMAT"), 'Sunday'),
-)
 
 utc = pytz.timezone('UTC')
-
-conference_datetimes = (
-    datetime(2015, 02, 19, tzinfo=utc),
-    datetime(2015, 02, 20, tzinfo=utc),
-    datetime(2015, 02, 21, tzinfo=utc),
-    datetime(2015, 02, 22, tzinfo=utc),
-)
-
-time_start = 8 * 60
-time_stop = 24 * 60
-
-conference_times = [(time(mins / 60, mins % 60),
-                     date_format(time(mins / 60, mins % 60),
-                                 "TIME_FORMAT"))
-                    for mins in range(time_start, time_stop, 30)]
-
-conference_dates = {"Thursday": "2015-02-19",
-                    "Friday": "2015-02-20",
-                    "Saturday": "2015-02-21",
-                    "Sunday": "2015-02-22"}
-
-hour = Duration(seconds=3600)
-
-monday = datetime(2015, 2, 23)
 
 
 def init_time_blocks(events,

--- a/expo/scheduler/views/remains.py
+++ b/expo/scheduler/views/remains.py
@@ -42,7 +42,6 @@ from gbe.duration import (
 )
 from scheduler.functions import (
     cal_times_for_conf,
-    conference_dates,
     event_info,
     overlap_clear,
     table_prep,
@@ -888,7 +887,7 @@ def calendar_view(request=None,
                                    duration,
                                    cal_start=cal_times[0],
                                    cal_stop=cal_times[1])
-        table['name'] = 'Event Calendar for the Great Burlesque Expo of 2015'
+        table['name'] = 'Event Calendar for the Great Burlesque Expo'
         table['link'] = 'http://burlesque-expo.com'
         table['x_name'] = {}
         table['x_name']['html'] = 'Rooms'

--- a/expo/tests/scheduler/test_detail_view.py
+++ b/expo/tests/scheduler/test_detail_view.py
@@ -6,7 +6,6 @@ import nose.tools as nt
 from django.test.client import RequestFactory
 from django.test import Client
 from scheduler.views import detail_view
-from scheduler.forms import conference_days
 from tests.factories.gbe_factories import (
     ProfileFactory,
     ShowFactory,


### PR DESCRIPTION
All the hard coded dates are dead code.  I removed them and refactored the one set that was actively in use to the file that was actually using it.

Reran all tests
gripped for any cases of the code - couldn’t find any 