### PR TITLE
GBE 950: separate conference list from schedule build

### DIFF
--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -227,3 +227,28 @@ def send_schedule_update_mail(participant_type, profile):
             'profile': profile},
         priority='now',
     )
+
+def get_gbe_schedulable_items(confitem_type, filter_type=None, conference=None):
+    '''
+    Queries the database for the conferece items relevant for each type
+    and returns a queryset.
+    '''
+    if confitem_type in ['Panel', 'Movement', 'Lecture', 'Workshop']:
+        filter_type, confitem_type = confitem_type, 'Class'
+    elif confitem_type in ['Special Event',
+                           'Volunteer Opportunity',
+                           'Master Class',
+                           'Drop-In Class']:
+        filter_type, confitem_type = confitem_type, 'GenericEvent'
+
+    if not conference:
+        conference = Conference.current_conf()
+    confitem_class = eval(confitem_type)
+    confitems_list = confitem_class.objects.filter(conference=conference)
+
+    if filter_type is not None:
+        confitems_list = [
+            confitem for confitem in confitems_list if
+            confitem.sched_payload['details']['type'] == filter_type]
+
+    return confitems_list

--- a/expo/scheduler/functions.py
+++ b/expo/scheduler/functions.py
@@ -278,7 +278,8 @@ def event_info(confitem_type='Show',
 
     confitems_list = get_gbe_schedulable_items(
         confitem_type,
-        filter_type)
+        filter_type,
+        conference)
 
     confitems_list = [confitem for confitem in confitems_list if
                       confitem.schedule_ready and confitem.visible]

--- a/expo/scheduler/functions.py
+++ b/expo/scheduler/functions.py
@@ -270,31 +270,18 @@ def event_info(confitem_type='Show',
                                    tzinfo=pytz.timezone('UTC'))),
                conference=None):
     '''
-    Queries the database for scheduled events of type confitem_type,
-    during time cal_times,
-    and returns their important information in a dictionary format.
+    Using the scheduleable items for the current conference, get a list
+    of dicts for the dates selected
     '''
-    if confitem_type in ['Panel', 'Movement', 'Lecture', 'Workshop']:
-        filter_type, confitem_type = confitem_type, 'Class'
-    elif confitem_type in ['Special Event',
-                           'Volunteer Opportunity',
-                           'Master Class',
-                           'Drop-In Class']:
-        filter_type, confitem_type = confitem_type, 'GenericEvent'
-
-    import gbe.models as conf
     from scheduler.models import Location
-    if not conference:
-        conference = conf.Conference.current_conf()
-    confitem_class = eval('conf.%s' % confitem_type)
-    confitems_list = confitem_class.objects.filter(conference=conference)
+    from gbe.functions import get_gbe_schedulable_items
+
+    confitems_list = get_gbe_schedulable_items(
+        confitem_type,
+        filter_type)
+
     confitems_list = [confitem for confitem in confitems_list if
                       confitem.schedule_ready and confitem.visible]
-
-    if filter_type is not None:
-        confitems_list = [
-            confitem for confitem in confitems_list if
-            confitem.sched_payload['details']['type'] == filter_type]
 
     loc_allocs = []
     for l in Location.objects.all():

--- a/expo/tests/scheduler/test_calendar_view.py
+++ b/expo/tests/scheduler/test_calendar_view.py
@@ -61,6 +61,7 @@ class TestCalendarView(TestCase):
         url = reverse('calendar_view', urlconf="scheduler.urls")
         data = {'conf': self.other_conference.conference_slug}
         response = self.client.get(url, data=data)
+        print (response.content)
         self.assertFalse(self.showcontext.show.title in response.content)
         self.assertTrue(self.other_show.show.title in response.content)
 

--- a/expo/tests/scheduler/test_calendar_view.py
+++ b/expo/tests/scheduler/test_calendar_view.py
@@ -61,7 +61,6 @@ class TestCalendarView(TestCase):
         url = reverse('calendar_view', urlconf="scheduler.urls")
         data = {'conf': self.other_conference.conference_slug}
         response = self.client.get(url, data=data)
-        print (response.content)
         self.assertFalse(self.showcontext.show.title in response.content)
         self.assertTrue(self.other_show.show.title in response.content)
 


### PR DESCRIPTION
I found a pretty clean, pretty small point of separation in this one function.

it not longer knows anything about gbe.models - but this increases the need to import gbe.model elements in gbe.functions — > many of which were originally failing in the original problem.