### PR TITLE
GBE 961: make volunteer registration easier

### DIFF
--- a/expo/gbe/templates/gbe/register.tmpl
+++ b/expo/gbe/templates/gbe/register.tmpl
@@ -8,7 +8,7 @@
 <H3>Create an Account</H3>
 
 In order to do most other things at The Expo, we need you to register
-for an account.  If you're planning on applying to perform, want to
+for a free account.  If you're planning on applying to perform, want to
 teach, or are going to be a vendor or a volunteer, you need to
 register.  You do <b>not</b> need to register if all you're doing is
 buying tickets.

--- a/expo/gbe/views/create_volunteer_view.py
+++ b/expo/gbe/views/create_volunteer_view.py
@@ -42,15 +42,15 @@ def no_vol_bidding(request):
     return HttpResponseRedirect(reverse('home', urlconf='gbe.urls'))
 
 
-@login_required
 @log_func
 def CreateVolunteerView(request):
     page_title = 'Volunteer'
     view_title = "Volunteer at the Expo"
+
     profile = validate_profile(request, require=False)
     formset = []
     if not profile:
-        return HttpResponseRedirect(reverse('profile',
+        return HttpResponseRedirect(reverse('register',
                                             urlconf='gbe.urls') +
                                     '?next=' +
                                     reverse('volunteer_create',

--- a/expo/tests/gbe/test_create_volunteer.py
+++ b/expo/tests/gbe/test_create_volunteer.py
@@ -81,8 +81,10 @@ class TestCreateVolunteer(TestCase):
         url = reverse(self.view_name,
                       urlconf='gbe.urls')
         login_as(UserFactory(), self)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
+        response = self.client.get(url, follow=True)
+        self.assertRedirects(
+            response,
+            reverse('register',urlconf='gbe.urls'))
 
     def test_create_volunteer_post_no_profile(self):
         url = reverse(self.view_name,

--- a/expo/tests/gbe/test_create_volunteer.py
+++ b/expo/tests/gbe/test_create_volunteer.py
@@ -85,7 +85,7 @@ class TestCreateVolunteer(TestCase):
         self.assertRedirects(
             response,
             "%s?next=%s" % (
-                reverse('register',urlconf='gbe.urls'),
+                reverse('register', urlconf='gbe.urls'),
                 url))
 
     def test_create_volunteer_post_no_profile(self):

--- a/expo/tests/gbe/test_create_volunteer.py
+++ b/expo/tests/gbe/test_create_volunteer.py
@@ -84,7 +84,9 @@ class TestCreateVolunteer(TestCase):
         response = self.client.get(url, follow=True)
         self.assertRedirects(
             response,
-            reverse('register',urlconf='gbe.urls'))
+            "%s?next=%s" % (
+                reverse('register',urlconf='gbe.urls'),
+                url))
 
     def test_create_volunteer_post_no_profile(self):
         url = reverse(self.view_name,


### PR DESCRIPTION
#961 


Fix the flow to go to registering an account on the premise that most volunteers are new to the expo.  As it turned out “login_required” as an annotation will ALWAYS route you to the login page, not to the account page.  So I had to remove it.  Our logic inside the function protects us anyway.

Also fix wording.

Since I tweaked the logic, I also updated the test to be more specific (it would have passed either way).  