### PR TITLE
GBE 945&709: show accepted class, and add a way to put an image for teachers with no photo

### DIFF
--- a/expo/gbe/templates/gbe/bio_list.tmpl
+++ b/expo/gbe/templates/gbe/bio_list.tmpl
@@ -1,5 +1,6 @@
 {% extends "base.tmpl" %}
 {% load ticketing_filters %}
+{% load staticfiles cms_tags %}
 {% block title %}
   Great Burlesque Exposition: {{title}}
 {% endblock %}
@@ -33,11 +34,14 @@
         {{teacher.bio.bio |linebreaksbr}}
         <br><br>
       </div>
-        {% if teacher.bio.promo_mini %}
         <div class="bio_image_block">
+        {% if teacher.bio.promo_mini %}
         <img src="{{MEDIA_URL}}{{teacher.bio.promo_mini}}" class="sched_bio_image">
-        </div>
+        {% else %}
+        {% static_placeholder "default_performer" %}
+
         {% endif %}
+        </div>
     {% endfor %}
 
 {% endblock %}

--- a/expo/gbe/templates/gbe/bio_list.tmpl
+++ b/expo/gbe/templates/gbe/bio_list.tmpl
@@ -22,8 +22,12 @@
         <h2>About {{teacher.bio.name}}</h2>
 	{% for class in teacher.classes %}
 	  <b>{{ class.role }}</b> -
-	  <a href='{% url 'scheduler:detail_view' class.event.eventitem.eventitem_id  %}'>
+	  {% if class.detail_id %}
+	  <a href='{% url 'scheduler:detail_view' class.detail_id  %}'>
 	  {{ class.event }}</a></br>
+	{% else %}
+	  {{ class.event }}</br>
+	{% endif %}
 	{% endfor %}
 	</br>
         {{teacher.bio.bio |linebreaksbr}}

--- a/expo/gbe/views/bios_teachers_view.py
+++ b/expo/gbe/views/bios_teachers_view.py
@@ -47,7 +47,7 @@ def BiosTeachersView(request):
                     'detail_id': commit.event.eventitem.eventitem_id}]
         for a_class in bid_classes.filter(teacher=performer):
             if len(commits.filter(
-                event__eventitem__event__class=a_class)) == 0:
+                    event__eventitem__event__class=a_class)) == 0:
                 classes += [{
                     'role': "Teacher",
                     'event': a_class}]

--- a/expo/gbe/views/bios_teachers_view.py
+++ b/expo/gbe/views/bios_teachers_view.py
@@ -46,7 +46,8 @@ def BiosTeachersView(request):
                     'event': commit.event,
                     'detail_id': commit.event.eventitem.eventitem_id}]
         for a_class in bid_classes.filter(teacher=performer):
-            if len(commits.filter(event__eventitem__event__class=a_class)) == 0:
+            if len(commits.filter(
+                event__eventitem__event__class=a_class)) == 0:
                 classes += [{
                     'role': "Teacher",
                     'event': a_class}]

--- a/expo/gbe/views/bios_teachers_view.py
+++ b/expo/gbe/views/bios_teachers_view.py
@@ -1,12 +1,9 @@
 from django.shortcuts import render
-from django.db.models import Q
 from django.core.urlresolvers import reverse
-
 from expo.gbe_logging import log_func
 
-from scheduler.models import (
-    ResourceAllocation,
-    Worker,
+from scheduler.functions import (
+    get_scheduled_events_by_role,
 )
 from gbe.models import Performer
 from gbe.functions import (
@@ -22,27 +19,23 @@ def BiosTeachersView(request):
     Display the teachers bios.  Teachers are anyone teaching,
     moderating or being a panelist.
     '''
-    current_conf = get_current_conference()
     conf_slug = request.GET.get('conference', None)
     if not conf_slug:
-        conference = current_conf
+        conference = get_current_conference()
     else:
         conference = get_conference_by_slug(conf_slug)
     conferences = conference_list()
-
     performers = Performer.objects.all()
-    commits = ResourceAllocation.objects.all()
-    workers = Worker.objects.filter(Q(role="Teacher") |
-                                    Q(role="Moderator") |
-                                    Q(role="Panelist"))
     bios = []
+    workers, commits = get_scheduled_events_by_role(
+        conference,
+        ["Teacher", "Moderator", "Panelist"])
 
     for performer in performers:
         classes = []
         for worker in workers.filter(_item=performer):
             for commit in commits.filter(resource=worker):
-                if commit.event.eventitem.get_conference() == conference:
-                    classes += [{'role': worker.role, 'event': commit.event}]
+                classes += [{'role': worker.role, 'event': commit.event}]
         if len(classes) > 0:
             bios += [{'bio': performer, 'classes': classes}]
 

--- a/expo/gbe/views/bios_teachers_view.py
+++ b/expo/gbe/views/bios_teachers_view.py
@@ -5,7 +5,10 @@ from expo.gbe_logging import log_func
 from scheduler.functions import (
     get_scheduled_events_by_role,
 )
-from gbe.models import Performer
+from gbe.models import (
+    Class,
+    Performer,
+)
 from gbe.functions import (
     get_current_conference,
     get_conference_by_slug,
@@ -26,6 +29,9 @@ def BiosTeachersView(request):
         conference = get_conference_by_slug(conf_slug)
     conferences = conference_list()
     performers = Performer.objects.all()
+    bid_classes = Class.objects.filter(
+        conference=conference,
+        accepted=3)
     bios = []
     workers, commits = get_scheduled_events_by_role(
         conference,
@@ -35,7 +41,16 @@ def BiosTeachersView(request):
         classes = []
         for worker in workers.filter(_item=performer):
             for commit in commits.filter(resource=worker):
-                classes += [{'role': worker.role, 'event': commit.event}]
+                classes += [{
+                    'role': worker.role,
+                    'event': commit.event,
+                    'detail_id': commit.event.eventitem.eventitem_id}]
+        for a_class in bid_classes.filter(teacher=performer):
+            if len(commits.filter(event__eventitem__event__class=a_class)) == 0:
+                classes += [{
+                    'role': "Teacher",
+                    'event': a_class}]
+
         if len(classes) > 0:
             bios += [{'bio': performer, 'classes': classes}]
 

--- a/expo/scheduler/functions.py
+++ b/expo/scheduler/functions.py
@@ -394,6 +394,7 @@ def get_roles_from_scheduler(workeritems, conference):
 
     return list(set(roles))
 
+
 def get_scheduled_events_by_role(conference, roles):
     '''
     gets all the workeritems scheduled with a given set of roles for the

--- a/expo/scheduler/functions.py
+++ b/expo/scheduler/functions.py
@@ -20,7 +20,6 @@ from expo.settings import (
     DAY_FORMAT,
 )
 from django.utils.formats import date_format
-
 from django.core.urlresolvers import reverse
 import pytz
 
@@ -394,3 +393,17 @@ def get_roles_from_scheduler(workeritems, conference):
             roles += [allocation.resource.as_subtype.role]
 
     return list(set(roles))
+
+def get_scheduled_events_by_role(conference, roles):
+    '''
+    gets all the workeritems scheduled with a given set of roles for the
+    given conference
+    '''
+    from scheduler.models import (
+        ResourceAllocation,
+        Worker,
+    )
+    commits = ResourceAllocation.objects.filter(
+        event__eventitem__event__conference=conference)
+    workers = Worker.objects.filter(role__in=roles)
+    return workers, commits

--- a/expo/tests/gbe/test_bios_teachers.py
+++ b/expo/tests/gbe/test_bios_teachers.py
@@ -34,6 +34,7 @@ class TestBiosTeachers(TestCase):
     view_name = 'bios_teacher'
 
     def setUp(self):
+        Conference.objects.all().delete()
         self.client = Client()
         self.performer = PersonaFactory()
 
@@ -59,7 +60,7 @@ class TestBiosTeachers(TestCase):
         # inheritance and factory boy, but that is not clear
         # to me.
         # Leaving them commented out to encourage us to
-        # fix
+        # fix (still broken - 1/12/17)
         # assert other_context.teacher.name not in response.content
         # assert other_context.bid.title not in response.content
 
@@ -83,3 +84,16 @@ class TestBiosTeachers(TestCase):
         # fix
         # assert other_context.bid.teacher.name not in response.content
         # assert other_context.bid.title not in response.content
+
+    def test_bios_teachers_unbooked_accepted(self):
+        accepted_class = ClassFactory(conference=current_conference(),
+                                      accepted=3)
+        url = reverse(self.view_name, urlconf="gbe.urls")
+        login_as(ProfileFactory(), self)
+        response = self.client.get(
+            url,
+            data={'conference': accepted_class.conference.conference_slug})
+
+        assert response.status_code == 200
+        assert accepted_class.teacher.name in response.content
+        assert accepted_class.title in response.content


### PR DESCRIPTION
To manually test - 
- 709 - if you’re using recent data, compare: 

http://www.burlesque-expo.com/bios/teachers?conference=GBE2016

and 

localhost (same URL)

Around ‘Roman Sirotin’ the view is messed up on the site, and OK on the  fixed branch.  Also - if you want to check the django-cms - you can now add a placeholder image via django-cms, so that I don’t have to care what image Scratch wants.

————

945 - also notice that if you use the current conference (http://localhost:8282/bios/teachers), the accepted classes show up, even if they aren’t scheduled yet.

Unscheduled classes don’t have details that show up in the scheduler views, so the teacher’s classes are listed by title w no link when they are unscheduled, and with a  link after they are scheduled for a time and date.
