### PR TITLE
GBE 955: check fees per conference

### DIFF
--- a/expo/gbe/ticketing_idd_interface.py
+++ b/expo/gbe/ticketing_idd_interface.py
@@ -84,15 +84,9 @@ def verify_performer_app_paid(user_name, conference):
                 act_fees_purchased += 1
 
     # Then figure out how many acts have already been submitted.
-    for act in Act.objects.filter(submitted=True, conference=conference):
-        act_user_name = None
-        try:
-            # user may not exist, so just skip for an exception
-            act_user_name = act.performer.contact.user_object.username
-        except:
-            pass
-        if act_user_name == unicode(user_name):
-            acts_submitted += 1
+    acts_submitted = Act.objects.filter(
+        submitted=True,
+        conference=conference).count()
     logger.info("Purchased Count:  %s  Submitted Count:  %s" %
                 (act_fees_purchased, acts_submitted))
     return act_fees_purchased > acts_submitted
@@ -124,15 +118,9 @@ def verify_vendor_app_paid(user_name, conference):
                 vendor_fees_purchased += 1
 
     # Then figure out how many vendor applications have already been submitted.
-    for vendor in Vendor.objects.filter(submitted=True, conference=conference):
-        vendor_user_name = None
-        try:
-            # user may not exist, so just skip for an exception
-            vendor_user_name = vendor.profile.user_object.username
-        except:
-            pass
-        if vendor_user_name == unicode(user_name):
-            vendor_apps_submitted += 1
+    vendor_apps_submitted = Vendor.objects.filter(
+        submitted=True,
+        conference=conference).count()
     logger.info("Purchased Count:  %s  Submitted Count:  %s" %
                 (vendor_fees_purchased, vendor_apps_submitted))
     return vendor_fees_purchased > vendor_apps_submitted

--- a/expo/gbe/ticketing_idd_interface.py
+++ b/expo/gbe/ticketing_idd_interface.py
@@ -58,7 +58,7 @@ def vendor_submittal_link(user_id):
     return None
 
 
-def verify_performer_app_paid(user_name):
+def verify_performer_app_paid(user_name, conference):
     '''
     Verifies if a user has paid his or her application fee.
     NOTE:  This function assumes that there is a record of the application,
@@ -74,7 +74,8 @@ def verify_performer_app_paid(user_name):
 
     # First figure out how many acts this user has purchased
     for act_event in BrownPaperEvents.objects.filter(
-            act_submission_event=True):
+            act_submission_event=True,
+            conference=conference):
         for trans in Transaction.objects.all():
             trans_event = trans.ticket_item.ticket_id.split('-')[0]
             trans_user_name = trans.purchaser.matched_to_user.username
@@ -83,7 +84,7 @@ def verify_performer_app_paid(user_name):
                 act_fees_purchased += 1
 
     # Then figure out how many acts have already been submitted.
-    for act in Act.objects.filter(submitted=True):
+    for act in Act.objects.filter(submitted=True, conference=conference):
         act_user_name = None
         try:
             # user may not exist, so just skip for an exception
@@ -97,7 +98,7 @@ def verify_performer_app_paid(user_name):
     return act_fees_purchased > acts_submitted
 
 
-def verify_vendor_app_paid(user_name):
+def verify_vendor_app_paid(user_name, conference):
     '''
     Verifies user has paid a vendor submittal fee.
     NOTE:  This function assumes that there is a record of the application,
@@ -112,7 +113,8 @@ def verify_vendor_app_paid(user_name):
 
     # First figure out how many vendor spots this user has purchased
     for vendor_event in BrownPaperEvents.objects.filter(
-            vendor_submission_event=True):
+            vendor_submission_event=True,
+            conference=conference):
         for trans in Transaction.objects.all():
             trans_event = trans.ticket_item.ticket_id.split('-')[0]
             trans_user_name = trans.purchaser.matched_to_user.username
@@ -122,7 +124,7 @@ def verify_vendor_app_paid(user_name):
                 vendor_fees_purchased += 1
 
     # Then figure out how many vendor applications have already been submitted.
-    for vendor in Vendor.objects.filter(submitted=True):
+    for vendor in Vendor.objects.filter(submitted=True, conference=conference):
         vendor_user_name = None
         try:
             # user may not exist, so just skip for an exception

--- a/expo/gbe/views/bid_act_view.py
+++ b/expo/gbe/views/bid_act_view.py
@@ -128,7 +128,7 @@ def BidActView(request):
             If this is a formal submit request, did they pay?
             They can't submit w/out paying
             '''
-            if verify_performer_app_paid(request.user.username):
+            if verify_performer_app_paid(request.user.username, conference):
                 act.submitted = True
                 act.save()
             else:

--- a/expo/gbe/views/create_vendor_view.py
+++ b/expo/gbe/views/create_vendor_view.py
@@ -54,7 +54,7 @@ def CreateVendorView(request):
             If this is a formal submit request, did they pay?
             They can't submit w/out paying
             '''
-            if verify_vendor_app_paid(request.user.username):
+            if verify_vendor_app_paid(request.user.username, conference):
                 vendor.submitted = True
                 conference = Conference.objects.filter(
                     accepting_bids=True).first()

--- a/expo/gbe/views/edit_act_view.py
+++ b/expo/gbe/views/edit_act_view.py
@@ -133,7 +133,8 @@ def EditActView(request, act_id):
             If this is a formal submit request, did they pay?
             They can't submit w/out paying
             '''
-            if verify_performer_app_paid(request.user.username):
+            if verify_performer_app_paid(request.user.username,
+                                         act.conference):
                 act.submitted = True
                 act.save()
             else:

--- a/expo/gbe/views/edit_vendor_view.py
+++ b/expo/gbe/views/edit_vendor_view.py
@@ -71,7 +71,8 @@ def EditVendorView(request, vendor_id):
             If this is a formal submit request, did they pay?
             They can't submit w/out paying
             '''
-            if verify_vendor_app_paid(request.user.username):
+            if verify_vendor_app_paid(request.user.username,
+                                      vendor.conference):
                 vendor.submitted = True
                 vendor.save()
                 user_message = UserMessage.objects.get_or_create(

--- a/expo/tests/functions/gbe_functions.py
+++ b/expo/tests/functions/gbe_functions.py
@@ -133,10 +133,11 @@ def assert_interest_view(response, interest):
         assert_has_help_text(response, interest.interest.help_text)
 
 
-def make_act_app_purchase(user_object):
+def make_act_app_purchase(conference, user_object):
     purchaser = PurchaserFactory(
         matched_to_user=user_object)
     transaction = TransactionFactory(purchaser=purchaser)
+    transaction.ticket_item.bpt_event.conference = conference
     transaction.ticket_item.bpt_event.act_submission_event = True
     transaction.ticket_item.bpt_event.bpt_event_id = "111111"
     transaction.ticket_item.bpt_event.save()

--- a/expo/tests/gbe/test_bid_act.py
+++ b/expo/tests/gbe/test_bid_act.py
@@ -167,7 +167,8 @@ class TestBidAct(TestCase):
     def test_act_submit_second_paid_act(self):
         prev_act = ActFactory(
             submitted=True,
-            performer=self.performer)
+            performer=self.performer,
+            conference=self.current_conference)
         make_act_app_purchase(self.current_conference,
                               self.performer.performer_profile.user_object)
         response, data = self.post_paid_act_submission()

--- a/expo/tests/gbe/test_bid_act.py
+++ b/expo/tests/gbe/test_bid_act.py
@@ -58,13 +58,13 @@ class TestBidAct(TestCase):
         return form_dict
 
     def post_paid_act_submission(self, act_form=None):
-        current_conference()
         if not act_form:
             act_form = self.get_act_form()
         url = reverse(self.view_name, urlconf='gbe.urls')
         login_as(self.performer.performer_profile, self)
         act_form.update({'submit': ''})
-        make_act_app_purchase(self.performer.performer_profile.user_object)
+        make_act_app_purchase(self.current_conference,
+                              self.performer.performer_profile.user_object)
         response = self.client.post(url, data=act_form, follow=True)
         return response, act_form
 
@@ -154,11 +154,22 @@ class TestBidAct(TestCase):
         self.assertContains(response, "View</a> act")
         self.assertContains(response, data['theact-title'])
 
+    def test_act_submit_paid_act_w_old_comp_act(self):
+        prev_act = ActFactory(
+            submitted=True,
+            performer=self.performer,
+            conference=ConferenceFactory(status='completed'))
+        response, data = self.post_paid_act_submission()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "View</a> act")
+        self.assertContains(response, data['theact-title'])
+
     def test_act_submit_second_paid_act(self):
         prev_act = ActFactory(
             submitted=True,
             performer=self.performer)
-        make_act_app_purchase(self.performer.performer_profile.user_object)
+        make_act_app_purchase(self.current_conference,
+                              self.performer.performer_profile.user_object)
         response, data = self.post_paid_act_submission()
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "View</a> act")

--- a/expo/tests/gbe/test_create_vendor.py
+++ b/expo/tests/gbe/test_create_vendor.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.test import Client
 from django.core.urlresolvers import reverse
 from tests.factories.gbe_factories import (
+    ConferenceFactory,
     ProfileFactory,
     UserFactory,
     UserMessageFactory,
@@ -126,6 +127,18 @@ class TestCreateVendor(TestCase):
         self.assertIn('Vendor Application', response.content)
 
     def test_create_vendor_post_with_vendor_app_paid(self):
+        response, data = self.post_paid_vendor_submission()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Profile View", response.content)
+        self.assertContains(response, "(Click to view)")
+        self.assertContains(response, data['title'])
+
+    def test_create_vendor_post_with_vendor_old_comp(self):
+        comped_vendor = VendorFactory(
+            submitted=True,
+            profile=self.profile,
+            conference=ConferenceFactory(status='completed')
+        )
         response, data = self.post_paid_vendor_submission()
         self.assertEqual(response.status_code, 200)
         self.assertIn("Profile View", response.content)

--- a/expo/tests/gbe/test_create_vendor.py
+++ b/expo/tests/gbe/test_create_vendor.py
@@ -148,7 +148,8 @@ class TestCreateVendor(TestCase):
     def test_create_vendor_post_with_second_vendor_app_paid(self):
         prev_vendor = VendorFactory(
             submitted=True,
-            profile=self.profile
+            profile=self.profile,
+            conference=self.conference
         )
         make_vendor_app_purchase(self.conference, self.profile.user_object)
         response, data = self.post_paid_vendor_submission()

--- a/expo/tests/gbe/test_edit_act.py
+++ b/expo/tests/gbe/test_edit_act.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 from django.test import Client
 from tests.factories.gbe_factories import (
     ActFactory,
+    ConferenceFactory,
     PersonaFactory,
     ProfileFactory,
     UserFactory,
@@ -57,7 +58,9 @@ class TestEditAct(TestCase):
                       args=[act.pk],
                       urlconf="gbe.urls")
         login_as(act.performer.performer_profile, self)
-        make_act_app_purchase(act.performer.performer_profile.user_object)
+        make_act_app_purchase(
+            act.conference,
+            act.performer.performer_profile.user_object)
         response = self.client.post(
             url,
             data=act_form,
@@ -69,7 +72,9 @@ class TestEditAct(TestCase):
         url = reverse(self.view_name,
                       args=[original.pk],
                       urlconf="gbe.urls")
-        make_act_app_purchase(original.performer.performer_profile.user_object)
+        make_act_app_purchase(
+            original.conference,
+            original.performer.performer_profile.user_object)
         return post_act_conflict(
             original.conference,
             original.performer,
@@ -135,6 +140,22 @@ class TestEditAct(TestCase):
 
     def test_act_edit_post_form_submit_unpaid(self):
         act = ActFactory()
+        url = reverse(self.view_name,
+                      args=[act.pk],
+                      urlconf="gbe.urls")
+        login_as(act.performer.performer_profile, self)
+        response = self.client.post(
+            url,
+            data=self.get_act_form(act, submit=True))
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue('Act Payment' in response.content)
+
+    def test_act_edit_post_form_submit_paid_other_year(self):
+        act = ActFactory()
+        make_act_app_purchase(
+            ConferenceFactory(
+                status="completed"),
+            act.performer.performer_profile.user_object)
         url = reverse(self.view_name,
                       args=[act.pk],
                       urlconf="gbe.urls")


### PR DESCRIPTION
Added a filter to check that only acts and fees within a conference are compared.  

A way to test - using the betty account, try to submit a vendor and act on this year’s conference - it will fail because although I have spare fees, they are on old conferences.

This can also be done in reverse - find a current conference bidder (act or vendor), make sure act/vendor is not submitted.  Remove older transactions for fees from old conferences, and check that it’s still OK to re-submit the act bid.