### PR TITLE
GBE 699: prevent volunteers from submitting with no phone or badgename

### DIFF
--- a/expo/gbe/models/act.py
+++ b/expo/gbe/models/act.py
@@ -19,6 +19,7 @@ from gbe.models import (
 )
 from gbetext import (
     acceptance_states,
+    act_alerts,
     act_not_unique,
     video_options,
 )

--- a/expo/gbe/models/profile.py
+++ b/expo/gbe/models/profile.py
@@ -66,6 +66,10 @@ class Profile(WorkerItem):
     how_heard = TextField(blank=True)
 
     @property
+    def complete(self):
+        return self.display_name and self.phone
+
+    @property
     def review_header(self):
         return (['Name',
                  'Username',

--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -85,9 +85,8 @@ div#middle {
 }
 
 div.left_col {
-    width:46%;
+    width:52%;
     float:left;
-    margin: 10px;
     padding: 10px;
     bottom: 10%;
 }

--- a/expo/gbe/templates/gbe/update_profile.tmpl
+++ b/expo/gbe/templates/gbe/update_profile.tmpl
@@ -23,6 +23,12 @@ etc.).
 
 
 <form method="POST" action="" enctype="multipart/form-data">
+  {% for form in left_forms %}
+    {% if form.errors %}
+      <p style= "color:red"> There is an error on the form.  </p>
+    {% endif %}
+  {% endfor %}
+
 <div class="colmask">
 <div class = "left_col">
   {% for form in left_forms %}

--- a/expo/gbe/views/create_volunteer_view.py
+++ b/expo/gbe/views/create_volunteer_view.py
@@ -25,6 +25,7 @@ from gbetext import (
     default_volunteer_no_interest_msg,
     default_volunteer_no_bid_msg,
     existing_volunteer_msg,
+    no_profile_msg,
 )
 from gbe.views.volunteer_display_functions import (
     validate_interests,
@@ -55,7 +56,19 @@ def CreateVolunteerView(request):
                                     '?next=' +
                                     reverse('volunteer_create',
                                             urlconf='gbe.urls'))
-
+    if not profile.complete:
+        user_message = UserMessage.objects.get_or_create(
+            view='CreateVolunteerView',
+            code="PROFILE_INCOMPLETE",
+            defaults={
+                'summary': "Volunteer Profile Incomplete",
+                'description': no_profile_msg})
+        messages.warning(request, user_message[0].description)
+        return HttpResponseRedirect(reverse('profile_update',
+                                            urlconf='gbe.urls') +
+                                    '?next=' +
+                                    reverse('volunteer_create',
+                                            urlconf='gbe.urls'))
     try:
         conference = Conference.objects.filter(accepting_bids=True).first()
         windows = conference.windows()

--- a/expo/gbe/views/create_volunteer_view.py
+++ b/expo/gbe/views/create_volunteer_view.py
@@ -47,16 +47,16 @@ def no_vol_bidding(request):
 def CreateVolunteerView(request):
     page_title = 'Volunteer'
     view_title = "Volunteer at the Expo"
-
-    profile = validate_profile(request, require=False)
-    formset = []
-    if not profile:
+    if not request.user.is_authenticated():
         return HttpResponseRedirect(reverse('register',
                                             urlconf='gbe.urls') +
                                     '?next=' +
                                     reverse('volunteer_create',
                                             urlconf='gbe.urls'))
-    if not profile.complete:
+
+    profile = validate_profile(request, require=False)
+    formset = []
+    if not profile or not profile.complete:
         user_message = UserMessage.objects.get_or_create(
             view='CreateVolunteerView',
             code="PROFILE_INCOMPLETE",

--- a/expo/gbe/views/register_view.py
+++ b/expo/gbe/views/register_view.py
@@ -25,6 +25,12 @@ def RegisterView(request):
             user = authenticate(username=username,
                                 password=password)
             login(request, user)
+            if request.GET.get('next', None):
+                return HttpResponseRedirect(
+                    reverse('profile_update',
+                            urlconf='gbe.urls')
+                    + '?next=' + request.GET['next'])
+
             return HttpResponseRedirect(reverse('profile_update',
                                                 urlconf='gbe.urls'))
     else:

--- a/expo/gbe/views/register_view.py
+++ b/expo/gbe/views/register_view.py
@@ -27,9 +27,9 @@ def RegisterView(request):
             login(request, user)
             if request.GET.get('next', None):
                 return HttpResponseRedirect(
-                    reverse('profile_update',
-                            urlconf='gbe.urls')
-                    + '?next=' + request.GET['next'])
+                    reverse(
+                        'profile_update',
+                        urlconf='gbe.urls') + '?next=' + request.GET['next'])
 
             return HttpResponseRedirect(reverse('profile_update',
                                                 urlconf='gbe.urls'))

--- a/expo/gbe/views/update_profile_view.py
+++ b/expo/gbe/views/update_profile_view.py
@@ -41,7 +41,7 @@ def UpdateProfileView(request):
                                             prefix='prefs')
         if form.is_valid():
             form.save(commit=True)
-            if profile.display_name.strip() == '':
+            if form.cleaned_data['display_name'].strip() == '':
                 profile.display_name = "%s %s" % (
                     request.user.first_name.strip(),
                     request.user.last_name.strip())

--- a/expo/gbe/views/update_profile_view.py
+++ b/expo/gbe/views/update_profile_view.py
@@ -60,7 +60,11 @@ def UpdateProfileView(request):
                     'summary': "Update Profile Success",
                     'description': default_update_profile_msg})
             messages.success(request, user_message[0].description)
-            return HttpResponseRedirect(reverse('home', urlconf='gbe.urls'))
+            if request.GET.get('next', None):
+                redirect_to = request.GET['next']
+            else:
+                redirect_to = reverse('home', urlconf='gbe.urls')
+            return HttpResponseRedirect(redirect_to)
         else:
             return render(request, 'gbe/update_profile.tmpl',
                           {'left_forms': [form], 'right_forms': [prefs_form]})

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -324,3 +324,6 @@ default_act_title_conflict = '''You've aready created a draft or made a \
 submission for this act.  View or edit that act here:  <a href="%s">%s</a>'''
 act_not_unique = '''Please name this act with a different title, \
 or edit the existing act.'''
+no_profile_msg = '''Your profile is not complete, you must provide a first \
+and last name, a name we can use on your badge, and a phone number we can \
+use to notify you of changes to the schedule at run time.'''

--- a/expo/tests/gbe/test_update_profile.py
+++ b/expo/tests/gbe/test_update_profile.py
@@ -98,6 +98,7 @@ class TestUpdateProfile(TestCase):
     def test_update_profile_post_empty_display_name(self):
         data = self.get_form()
         data['display_name'] = ""
+        data['purchase_email'] = ""
         response = self.post_profile(form=data)
         self.assertTrue(
             "%s %s" % (data['first_name'],


### PR DESCRIPTION
There are details on the bottom of #699 of all the navigational paths.  I made sure that no matter what you do, the system will detect what you’re missing and get you to the right screen to fix it.

Put in the error message we wanted when a volunteer is found to be missing profile info.

Put in check that a profile is not “complete” if it does not have a display name and an email.