### PR TITLE
GBE 912: only show the shows for this conference

### DIFF
--- a/expo/scheduler/forms.py
+++ b/expo/scheduler/forms.py
@@ -33,6 +33,15 @@ class ActScheduleForm(forms.Form):
     show = forms.ModelChoiceField(queryset=Event.objects.all())
     order = forms.IntegerField()
 
+    def __init__(self, *args, **kwargs):
+        super(ActScheduleForm, self).__init__(*args, **kwargs)
+        if 'initial' in kwargs:
+            initial = kwargs.pop('initial')
+            conf_shows = conf.Show.objects.filter(
+                conference=initial['show'].eventitem.get_conference())
+            self.fields['show'].queryset = Event.objects.filter(
+                eventitem__in=conf_shows)
+
 
 class WorkerAllocationForm (forms.Form):
     '''

--- a/expo/tests/scheduler/test_schedule_acts.py
+++ b/expo/tests/scheduler/test_schedule_acts.py
@@ -107,7 +107,7 @@ class TestScheduleActs(TestCase):
         self.assert_good_form_display(response)
 
     def test_good_user_get_two_shows_same_title(self):
-        ShowFactory(title=self.context)
+        ShowFactory(title=self.context.show.title)
         login_as(self.privileged_profile, self)
         response = self.client.get(self.url)
         self.assert_good_form_display(response)
@@ -209,3 +209,9 @@ class TestScheduleActs(TestCase):
             reverse('home', urlconf='gbe.urls'))
         self.assertEqual(new_show.sched_event.volunteer_count, "2 acts")
         self.assertEqual(self.context.sched_event.volunteer_count, 0)
+
+    def test_good_user_get_only_conf_shows(self):
+        not_this_conf_show = ShowFactory()
+        login_as(self.privileged_profile, self)
+        response = self.client.get(self.url)
+        assert not_this_conf_show.title not in response.content


### PR DESCRIPTION
The manual test is pretty easy:
- use a recent dump of GBE
- go to ‘http://localhost:8282/scheduler/acts'
- select a show
- see that only 4 shows and “—“ show up.  And they load quite fast.

That’s it.  If you look at master, you’ll see the list gruesomely long, loads slow and expands off the real estate.

