### PR TITLE
GBE 957: Show shows on act/reviewlist

### DIFF
--- a/expo/gbe/models/act.py
+++ b/expo/gbe/models/act.py
@@ -141,12 +141,12 @@ class Act (Biddable, ActItem):
 
     @property
     def bid_review_summary(self):
-        try:
-            casting = ResourceAllocation.objects.filter(
-                resource__actresource___item=self.resourceitem_id)[0]
-            show_name = casting.event
-        except:
-            show_name = ''
+        show_name = ""
+        for show in self.get_scheduled_shows():
+            if len(show_name) > 0:
+                show_name += "%s, " % str(show.eventitem)
+            else:
+                show_name = str(show.eventitem)
 
         return (self.performer.name,
                 self.title,

--- a/expo/gbe/models/act.py
+++ b/expo/gbe/models/act.py
@@ -144,7 +144,7 @@ class Act (Biddable, ActItem):
         show_name = ""
         for show in self.get_scheduled_shows():
             if len(show_name) > 0:
-                show_name += "%s, " % str(show.eventitem)
+                show_name += ", %s" % str(show.eventitem)
             else:
                 show_name = str(show.eventitem)
 

--- a/expo/tests/contexts/show_context.py
+++ b/expo/tests/contexts/show_context.py
@@ -31,7 +31,8 @@ class ShowContext:
         self.days = self.conference.conferenceday_set.all()
         act = act or ActFactory(conference=self.conference,
                                 performer=self.performer,
-                                accepted=3)
+                                accepted=3,
+                                submitted=True)
         self.acts = [act]
         self.show = ShowFactory(conference=self.conference)
         self.room = room or RoomFactory()
@@ -63,7 +64,8 @@ class ShowContext:
 
     def book_act(self, act=None):
         act = act or ActFactory(conference=self.conference,
-                                accepted=3)
+                                accepted=3,
+                                submitted=True)
         booking = ResourceAllocationFactory(
             event=self.sched_event,
             resource=ActResourceFactory(_item=act))

--- a/expo/tests/gbe/test_review_act_list.py
+++ b/expo/tests/gbe/test_review_act_list.py
@@ -75,6 +75,18 @@ class TestReviewActList(TestCase):
         response = self.client.get(
             self.url,
             data={'conf_slug': context.conference.conference_slug})
-        print response.content
         assert context.acts[0].title in response.content
         assert context.show.title in response.content
+
+    def test_review_act_assigned_two_shows(self):
+        context = ShowContext()
+        context2 = ShowContext(
+            conference=context.conference,
+            act=context.acts[0])
+        login_as(self.privileged_user, self)
+        response = self.client.get(
+            self.url,
+            data={'conf_slug': context.conference.conference_slug})
+        assert context.acts[0].title in response.content
+        assert "%s, %s" % (context.show.title,
+                           context2.show.title) in response.content

--- a/expo/tests/gbe/test_review_act_list.py
+++ b/expo/tests/gbe/test_review_act_list.py
@@ -10,7 +10,9 @@ from tests.factories.gbe_factories import (
     PersonaFactory,
     ProfileFactory,
     UserFactory,
-    )
+
+)
+from tests.contexts import ShowContext
 from tests.functions.gbe_functions import (
     current_conference,
     grant_privilege,
@@ -66,3 +68,13 @@ class TestReviewActList(TestCase):
         self.assertContains(response, str(eval.primary_vote.show))
         self.assertContains(response, str(eval.secondary_vote.show))
         self.assertContains(response, str(eval.bid.title))
+
+    def test_review_act_assigned_show(self):
+        context = ShowContext()
+        login_as(self.privileged_user, self)
+        response = self.client.get(
+            self.url,
+            data={'conf_slug': context.conference.conference_slug})
+        print response.content
+        assert context.acts[0].title in response.content
+        assert context.show.title in response.content


### PR DESCRIPTION
#957 is a bug that came from refactoring the models.py into /models/*.py

In so doing, we didn’t import ResourceAllocatino, and the way the code was written, it failed silently and had no unit test backup.

Refactored and added code to:
- use scheduler in a way that means less cross-model contact.
- add unit tests to keep failure from remaining silent.