### PR TITLE
GBE 949: Accept Act is now show-sensitive

### DIFF
--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -185,7 +185,7 @@ def send_bid_state_change_mail(
         status,
         show=None):
     site = Site.objects.get_current()
-    context={
+    context = {
         'name': badge_name,
         'bid_type': bid_type,
         'bid': bid,

--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -23,6 +23,7 @@ from post_office.models import EmailTemplate
 from django.conf import settings
 import os
 from django.contrib.sites.models import Site
+from django.core.urlresolvers import reverse
 
 
 def validate_profile(request, require=False):
@@ -176,11 +177,18 @@ def get_or_create_template(name, base, subject):
         template.save()
 
 
-def send_bid_state_change_mail(bid_type, email, badge_name, status, show=None):
+def send_bid_state_change_mail(
+        bid_type,
+        email,
+        badge_name,
+        bid,
+        status,
+        show=None):
     site = Site.objects.get_current()
     context={
         'name': badge_name,
         'bid_type': bid_type,
+        'bid': bid,
         'status': acceptance_states[status][1],
         'site': site.domain,
         'site_name': site.name}
@@ -193,8 +201,14 @@ def send_bid_state_change_mail(bid_type, email, badge_name, status, show=None):
             bid_type,
             str(show))
         context['show'] = show
-        context['show_link'] = None
-        context['act_tech_link'] = None
+        context['show_link'] = reverse(
+            'detail_view',
+            args=[show.pk],
+            urlconf='scheduler.urls')
+        context['act_tech_link'] = reverse(
+            'act_techinfo_edit',
+            args=[show.pk],
+            urlconf='gbe.urls')
     else:
         name = '%s %s' % (bid_type, acceptance_states[status][1].lower())
         action = 'Your %s proposal has changed status to %s' % (

--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -222,24 +222,37 @@ def notify_reviewers_on_bid_change(bidder,
                                    action,
                                    conference,
                                    group_name,
-                                   review_url):
-    name = '%s %s notification' % (bid_type.lower(), action.lower())
+                                   review_url,
+                                   show=None):
+    context = {'bidder': bidder,
+               'bid_type': bid_type,
+               'action': action,
+               'conference': conference,
+               'group_name': group_name,
+               'review_url': Site.objects.get_current().domain+review_url}
+
+    if not show:
+        name = '%s %s notification' % (bid_type.lower(), action.lower())
+        action = "%s %s Occurred" % (bid_type, action)
+    else:
+        name = '%s %s for %s' % (
+            bid_type.lower(), action.lower(), str(show).lower())
+        action = "%s %s for %s" % (bid_type, action, str(show))
+        context['show'] = show
+        context['show_link'] = None
+        context['act_tech_link'] = None
+
     get_or_create_template(
         name,
         "bid_submitted",
-        "%s %s Occurred" % (bid_type, action))
+        action
+        )
     to_list = [user.email for user in
                User.objects.filter(groups__name=group_name)]
     mail.send(to_list,
               settings.DEFAULT_FROM_EMAIL,
               template=name,
-              context={
-                'bidder': bidder,
-                'bid_type': bid_type,
-                'action': action,
-                'conference': conference,
-                'group_name': group_name,
-                'review_url': Site.objects.get_current().domain+review_url},
+              context=context,
               priority='now',
               )
 

--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -184,20 +184,22 @@ def send_bid_state_change_mail(bid_type, email, badge_name, status, show=None):
         'status': acceptance_states[status][1],
         'site': site.domain,
         'site_name': site.name}
-    if not show:
-        name = '%s %s' % (bid_type, acceptance_states[status][1].lower())
-        action = 'Your %s proposal has changed status to %s' % (
-            bid_type,
-            acceptance_states[status][1])
-    else:
-        name = '%s %s %s' % (
-            bid_type.lower(), action.lower(), str(show).lower())
+    if show:
+        name = '%s %s - %s' % (
+            bid_type.lower(),
+            acceptance_states[status][1].lower(),
+            str(show).lower())
         action = 'Your %s has been cast in %s' % (
             bid_type,
             str(show))
         context['show'] = show
         context['show_link'] = None
         context['act_tech_link'] = None
+    else:
+        name = '%s %s' % (bid_type, acceptance_states[status][1].lower())
+        action = 'Your %s proposal has changed status to %s' % (
+            bid_type,
+            acceptance_states[status][1])
 
     get_or_create_template(
         name,

--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -201,11 +201,11 @@ def send_bid_state_change_mail(
             bid_type,
             str(show))
         context['show'] = show
-        context['show_link'] = reverse(
+        context['show_link'] = site.domain + reverse(
             'detail_view',
             args=[show.pk],
             urlconf='scheduler.urls')
-        context['act_tech_link'] = reverse(
+        context['act_tech_link'] = site.domain + reverse(
             'act_techinfo_edit',
             args=[show.pk],
             urlconf='gbe.urls')

--- a/expo/gbe/templates/gbe/email/default_bid_status_change.tmpl
+++ b/expo/gbe/templates/gbe/email/default_bid_status_change.tmpl
@@ -1,5 +1,19 @@
 Dear {{ name }},
 
-The status of your {{ bid_type }} has been changed to {{ status }}. You can
+The status of your {{ bid_type }} - {{ bid }} - has been changed to {{ status }}. You can
 always check the status of your submissions or your schedule by visiting
-your personal pane on {{site}}
+your personal pane on {{site}}.
+
+{% if show %}
+Congratulations!  Your act, {{ bid }} was cast in {{ show }}.  We've posted you as one of
+our performers on our show page:
+
+  {{ show_link }}
+  
+Be sure to fill out your Act Tech Info Page ASAP to help our awesome tech crew make your
+act the best it can be!  The form is here:
+
+  {{ act_tech_link }}
+  
+Congratulations again!  We look forward to seeing you at the Expo!
+{% endif %}

--- a/expo/gbe/templates/gbe/email/default_bid_status_change_html.tmpl
+++ b/expo/gbe/templates/gbe/email/default_bid_status_change_html.tmpl
@@ -1,5 +1,22 @@
 Dear {{ name }},
+<br><br>
 
 The status of your {{ bid_type }} has been changed to {{ status }}. You can
 always check the status of your submissions or your schedule by visiting
 your personal pane on <a href='{{site}}'>{{site_name}}</a>
+<br><br>
+
+{% if show %}
+Congratulations!  Your act, {{ bid }} was cast in {{ show }}.  We've posted you as one of
+our performers on our <a href="{{ show_link }}">show's promotion</a>!
+<br><br>
+  
+Be sure to fill out your Act Tech Info Page ASAP to help our awesome tech crew make your
+act the best it can be!  The form is here:
+<br><br>
+
+  <a href="{{ act_tech_link }}">Act Tech Information</a>
+<br><br>
+  
+Congratulations again!  We look forward to seeing you at the Expo!
+{% endif %}

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -61,19 +61,23 @@ class ActChangeStateView(BidChangeStateView):
             request)
 
     def notify_bidder(self, request):
+        email_show = None
         if (str(self.object.accepted) != request.POST['accepted']) or (
                 request.POST['accepted'] == '3'):
+            # only send the show when act is accepted
+            if request.POST['accepted'] == '3':
+                email_show = self.new_show
             send_bid_state_change_mail(
                 str(self.object_type.__name__).lower(),
                 self.bidder.contact_email,
                 self.bidder.get_badge_name(),
                 self.object,
                 int(request.POST['accepted']),
-                show=self.new_show)
+                show=email_show)
 
     def prep_bid(self, request, args, kwargs):
         super(ActChangeStateView, self).prep_bid(request, args, kwargs)
-        if request.POST['accepted'] == '3':
+        if self.act_accepted(request):
             self.new_show = get_object_or_404(
                 sEvent,
                 eventitem__event=request.POST['show'])

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -13,6 +13,7 @@ from expo.settings import (
 from django.utils.formats import date_format
 from gbe.views import BidChangeStateView
 from gbe.models import Act
+from gbe.functions import send_bid_state_change_mail
 
 
 class ActChangeStateView(BidChangeStateView):
@@ -34,7 +35,8 @@ class ActChangeStateView(BidChangeStateView):
         # Clear out previous castings, deletes ActResource and
         # ResourceAllocation
         old = ActResource.objects.filter(_item=self.object)
-        self.old_show = old[0].show
+        if len(old) > 0:
+            self.old_show = old[0].show
         old.delete()
 
         # if the act has been accepted, set the show.

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -19,6 +19,8 @@ class ActChangeStateView(BidChangeStateView):
     object_type = Act
     coordinator_permissions = ('Act Coordinator',)
     redirectURL = 'act_review_list'
+    new_show = None
+    old_show = None
 
     def get_bidder(self):
         self.bidder = self.object.performer.contact
@@ -31,20 +33,22 @@ class ActChangeStateView(BidChangeStateView):
     def bid_state_change(self, request):
         # Clear out previous castings, deletes ActResource and
         # ResourceAllocation
-        ActResource.objects.filter(_item=self.object).delete()
+        old = ActResource.objects.filter(_item=self.object)
+        self.old_show = old[0].show
+        old.delete()
 
         # if the act has been accepted, set the show.
         if self.act_accepted(request):
             # Cast the act into the show by adding it to the schedule
             # resource time
-            show = get_object_or_404(sEvent,
+            self.new_show = get_object_or_404(sEvent,
                                      eventitem__event=request.POST['show'])
             casting = ResourceAllocation()
-            casting.event = show
+            casting.event = self.new_show
             actresource = ActResource(_item=self.object)
             actresource.save()
             for worker in self.object.get_performer_profiles():
-                conflicts = worker.get_conflicts(show)
+                conflicts = worker.get_conflicts(self.new_show)
                 for problem in conflicts:
                     messages.warning(
                         request,
@@ -59,3 +63,21 @@ class ActChangeStateView(BidChangeStateView):
             casting.save()
         return super(ActChangeStateView, self).bid_state_change(
             request)
+
+    def notify_bidder(self, request):
+        show = None
+        if (str(self.object.accepted) != request.POST['accepted']) or (
+                self.new_show and (not self.old_show or (
+                    self.new_show != self.old_show))):
+            # if there was a meaningful change...
+            if request.POST['accepted'] == 3 and (
+                    not self.old_show or (self.new_show != self.old_show)):
+                # the change involved a change in show acceptance
+                show = self.new_show
+
+            send_bid_state_change_mail(
+                str(self.object_type.__name__).lower(),
+                self.bidder.contact_email,
+                self.bidder.get_badge_name(),
+                int(request.POST['accepted']),
+                show=show)

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -67,6 +67,7 @@ class ActChangeStateView(BidChangeStateView):
                 str(self.object_type.__name__).lower(),
                 self.bidder.contact_email,
                 self.bidder.get_badge_name(),
+                self.object,
                 int(request.POST['accepted']),
                 show=self.new_show)
 

--- a/expo/gbe/views/bid_changestate_view.py
+++ b/expo/gbe/views/bid_changestate_view.py
@@ -49,6 +49,7 @@ class BidChangeStateView(View):
                 str(self.object_type.__name__).lower(),
                 self.bidder.contact_email,
                 self.bidder.get_badge_name(),
+                self.object,
                 int(request.POST['accepted']))
 
     def groundwork(self, request, args, kwargs):


### PR DESCRIPTION
Change = when an act bid is accepted (Review -> Acts, select act, click Review, change the form on the right to accept and submit) - then the “act accepted” email now tells them what show they were cast into and creates/uses a specific template for that show (so there is 1 template for rhinestone review, 1 template for main event, etc).

Waitlist, reject, withdrawn, etc - do not do a per show view.

Fun fact:  there are 525 lines out of 6815 of code that are NOT tested.  A month ago, there were ~583 lines.  If we hit 504 lines of untested code, we will be at 93% coverage.