### PR TITLE
GBE 979: Speed up assign volunteers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,9 @@ expo/gbe/static/djangocms_text_ckeditor/*
 expo/gbe/static/djangocms_admin_style
 expo/gbe/static/djangocms_admin_style/*
 expo/gbe/static/treebeard/*
-
+expo/gbe/static/debug_toolbar/*
+expo/gbe/static/hijack/*
+expo/gbe/static/import_export/*
 expo/media*
 
 expo/expo/settings.pyc

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -55,3 +55,4 @@ wand
 django-ad-rotator
 django-post_office==2.0.8
 django-import-export==0.5.1
+sqlparse==0.1.19

--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -182,6 +182,7 @@ MIDDLEWARE_CLASSES = (
     #    end of add for django-cms
     'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
     'pagination.middleware.PaginationMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.cache.FetchFromCacheMiddleware',
 )
 

--- a/expo/expo/urls.py
+++ b/expo/expo/urls.py
@@ -15,6 +15,12 @@ if APP_DJANGOBB is True:
     LOCAL_APPS_URLS = LOCAL_APPS_URLS + (url(r'^forum/',
                                          include('djangobb_forum.urls',
                                                  namespace='djangobb')),)
+if settings.DEBUG:
+    import debug_toolbar
+    LOCAL_APPS_URLS += (
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )
+
 
 urlpatterns = ('',
                url(r'^', include('gbe.urls', namespace='gbe')),

--- a/expo/gbe/models/class_model.py
+++ b/expo/gbe/models/class_model.py
@@ -178,7 +178,7 @@ class Class(Biddable, Event):
                 acceptance_states[self.accepted][1])
 
     def __str__(self):
-        return self.title
+        return self.event_ptr.title
 
     # tickets that apply to class are:
     #   - any ticket that applies to "most"

--- a/expo/gbe/templates/gbe/assign_volunteer.tmpl
+++ b/expo/gbe/templates/gbe/assign_volunteer.tmpl
@@ -141,7 +141,7 @@
               {% if event_window.window in volunteer.unavailable_windows.all%}
                 Not Free<br>
               {% endif %}
-{% if event_window.event.eventitem.child.sched_payload.details.volunteer_category in volunteer.interest_list %}
+{% if event_window.event.eventitem.child.sched_payload.details.volunteer_category in interests %}
                 Interested<br>
               {% endif %}
             </td>

--- a/expo/gbe/views/assign_volunteer_view.py
+++ b/expo/gbe/views/assign_volunteer_view.py
@@ -17,7 +17,6 @@ from django.http import HttpResponseRedirect
 
 @login_required
 @log_func
-@never_cache
 def AssignVolunteerView(request, volunteer_id):
     '''
     Show a bid  which needs to be assigned to shifts by the coordinator.

--- a/expo/gbe/views/assign_volunteer_view.py
+++ b/expo/gbe/views/assign_volunteer_view.py
@@ -45,6 +45,7 @@ def AssignVolunteerView(request, volunteer_id):
                   'gbe/assign_volunteer.tmpl',
                   {'volunteer': volunteer,
                    'bookings': volunteer.profile.get_bookings('Volunteer'),
+                   'interests': volunteer.interest_list,
                    'volunteer_event_windows': get_events_and_windows(
                     conference),
                    'actionURL': actionURL,

--- a/expo/scheduler/models.py
+++ b/expo/scheduler/models.py
@@ -757,15 +757,15 @@ class Event(Schedulable):
 
     @property
     def volunteer_count(self):
-        acts = len(self.get_acts())
-        volunteers = Worker.objects.filter(allocations__event=self,
-                                           role='Volunteer').count()
-        if acts:
-            return "%d acts" % acts
-        elif volunteers:
+        allocations = ResourceAllocation.objects.filter(event=self)
+        volunteers = allocations.filter(resource__worker__role='Volunteer').count()
+        if volunteers > 0:
             return "%d volunteers" % volunteers
         else:
-            return 0
+            acts = ActResource.objects.filter(allocations__in=allocations).count()
+            if acts > 0:
+                return "%d acts" % acts
+        return 0
 
     def get_workers(self, worker_type=None):
         '''

--- a/expo/scheduler/models.py
+++ b/expo/scheduler/models.py
@@ -570,14 +570,7 @@ class EventItem (models.Model):
     def describe(self):
         try:
             child = self.child()
-            '''
-            ids = "event - " + str(child.event_id)
-            try:
-                ids += ', bid - ' + str(child.id)
-            except:
-                ids += ""
-            '''
-            return str(child.sched_payload.get('title'))
+            return str(child)
         except:
             return "no child"
 


### PR DESCRIPTION
On my test set, this brought me down to a little worse than 50% faster and with 1/2 the SQL queries.

To be even faster, I put caching back on the page.

Added django debug tool bar back, and had to fix some dependancies - if you want to test this with django debug toolbar, you’ll probably need to retrovision your vagrant.