### PR TITLE
GBE 983: display by half hour

### DIFF
--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -842,3 +842,8 @@ span.opps-errors > ul
 {
   padding: 0px;
 }
+
+.calendar_table .cal_body TH
+{
+  width: 80px;
+}

--- a/expo/scheduler/functions.py
+++ b/expo/scheduler/functions.py
@@ -17,8 +17,7 @@ import math
 from expo.settings import (
     DATETIME_FORMAT,
     TIME_FORMAT,
-    DAY_FORMAT,
-    TIME_ZONE,
+    DATE_FORMAT,
 )
 from django.utils.formats import date_format
 from django.core.urlresolvers import reverse
@@ -228,7 +227,7 @@ def html_headers(table, headerStart='<TH>', headerEnd='</TH>'):
 
 def table_prep(events,
                block_size,
-               time_format="DATETIME_FORMAT",
+               time_format="TIME_FORMAT",
                cal_start=None,
                cal_stop=None,
                col_heads=None):

--- a/expo/scheduler/templates/scheduler/sched_display.tmpl
+++ b/expo/scheduler/templates/scheduler/sched_display.tmpl
@@ -4,9 +4,9 @@
 {% endblock %}
 
 {% block content %}
-
+<h1 align='center'>{{ day }}</h1>
 {% if rows %}
-<table border=4, style="list-style: none;">
+<table border=4, style="list-style: none;" class="calendar_table">
 <CAPTION ALIGN="top">
 <li><a href="{{ x_name.link }}">{{ x_name.title }}</a></li></CAPTION>
 
@@ -30,7 +30,11 @@
 {% endcomment %}
 
   {% for row in rows %}
-     <tr>
+   {% if forloop.first %}
+     <tr class="cal_header">
+   {% else %}
+     <tr class="cal_body">
+   {% endif %}
     {% for cell in row %}
       {{cell |safe}}
     {% endfor %}

--- a/expo/scheduler/views/remains.py
+++ b/expo/scheduler/views/remains.py
@@ -64,6 +64,8 @@ from gbe.functions import (
 )
 from gbe.views.class_display_functions import get_scheduling_info
 from django.contrib import messages
+from expo.settings import DATE_FORMAT
+from django.utils.formats import date_format
 
 
 @login_required
@@ -838,7 +840,7 @@ def view_list(request, event_type='All'):
 def calendar_view(request=None,
                   event_type='Show',
                   day=None,
-                  duration=Duration(minutes=60)):
+                  duration=Duration(minutes=30)):
     conf_slug = request.GET.get('conf', None)
     if conf_slug:
         conf = get_conference_by_slug(conf_slug)
@@ -887,6 +889,14 @@ def calendar_view(request=None,
                                    duration,
                                    cal_start=cal_times[0],
                                    cal_stop=cal_times[1])
+        if day:
+            table['day'] = "%s - %s" % (
+                day,
+                date_format(cal_times[0], "DATE_FORMAT"))
+        else:
+            table['day'] = "%s - %s" % (
+                date_format(cal_times[0], "DATE_FORMAT"),
+                date_format(cal_times[1], "DATE_FORMAT"))
         table['name'] = 'Event Calendar for the Great Burlesque Expo'
         table['link'] = 'http://burlesque-expo.com'
         table['x_name'] = {}


### PR DESCRIPTION
This was all visual fixing, so no unit tests were added.  Same level of coverage as master.

Changes:
- changed the size of a block (i.e., a row in the table) to be 30 minutes
- this made the far left column ugly, so I tuned it to only show time, and have a fixed width
- to compensate for removing the date - I put the date at the top as a header.  Given that the function does both per-day, and a date range, I offered both options for date display.

- pepdiff = no problems
- unit tests - all run
- run coverage = 528 missing lines