### PR TITLE
GBE-978: Fixes the two menu open problem

### DIFF
--- a/expo/gbe/static/styles/gbe_bootstrap.min.css
+++ b/expo/gbe/static/styles/gbe_bootstrap.min.css
@@ -43,6 +43,12 @@ a:active,a:hover{
 	outline:0
 }
 
+@media (min-width: 767px) {
+    .navbar-nav .dropdown-menu .caret {
+	transform: rotate(-90deg);
+    }
+}
+
 h1{
 	margin:.67em 0;
 	font-size:2em
@@ -3775,9 +3781,9 @@ textarea.input-group-sm>.form-control,textarea.input-group-sm>.input-group-addon
 	background-color:transparent
 }
 
-.nav .open>a,.nav .open>a:hover,.nav .open>a:focus{
-	background-color:#eee;
-	border-color:#428bca
+.nav .open>a:hover,.nav .open>a:focus{
+	background-color:#000;
+	border-color:#428bca;
 }
 
 .nav .nav-divider{
@@ -4086,13 +4092,11 @@ textarea.input-group-sm>.form-control,textarea.input-group-sm>.input-group-addon
 
 .container>.navbar-header,.container>.navbar-collapse{
 	margin-right:-15px;
-	margin-left:-15px
 }
 
 @media(min-width:768px){
 	.container>.navbar-header,.container>.navbar-collapse{
 		margin-right:0;
-		margin-left:0
 	}
 
 }

--- a/expo/gbe/static/styles/menustyle.css
+++ b/expo/gbe/static/styles/menustyle.css
@@ -28,6 +28,7 @@ body {
     display:inline-block;
     margin:0 auto;
 }
+
 #nav {
     display:inline;
     text-align:left;

--- a/expo/templates/base.tmpl
+++ b/expo/templates/base.tmpl
@@ -45,21 +45,22 @@
     </div>
 
       <div class="navbar navbar-default" role="navigation">
-            <div class="navbar-header">
-              <button type="button" class="navbar-toggle" data-toggle="collapse"
- data-target=".navbar-collapse">
-                <span class="sr-only">Toggle navigation</span>
+        <div class="container">
+          <div class="navbar-header">
+            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+              <span class="sr-only">Toggle navigation</span>
                 <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-              </button>
-              <a class="navbar-brand" href="#">Menu:</a>
-            </div>
-            <div class="navbar-collapse collapse">
-              <ul class="nav navbar-nav">
-                {% show_menu 0 100 100 100 "menu.tmpl" %}
-              </ul>
-            </div>
+                  <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+            </button>
+            <a class="navbar-brand" href="#">NavBar</a>
+          </div>
+          <div class="collapse navbar-collapse">
+            <ul class="nav navbar-nav">
+	      {% show_menu 0 100 100 100 "menu.tmpl" %}
+            </ul>
+          </div>
+        </div><!-- /.container -->
       </div>
       <div class="main-content" >
         {% if messages %}
@@ -80,28 +81,20 @@
 
   </body>
 </html>
-
 <script>
-$(document).ready(function(){
-	$(".dropdown-menu > li > a.trigger").on("click",function(e){
-		var current=$(this).next();
-		var grandparent=$(this).parent().parent();
-		if($(this).hasClass('left-caret')||$(this).hasClass('right-caret'))
-			$(this).toggleClass('right-caret left-caret');
-		grandparent.find('.left-caret').not(this).toggleClass('right-caret left-caret');
-		grandparent.find(".sub-menu:visible").not(current).hide();
-		current.toggle();
-		e.stopPropagation();
-	});
-	$(".dropdown-menu > li > a:not(.trigger)").on("click",function(){
-		var root=$(this).closest('.dropdown');
-		root.find('.left-caret').toggleClass('right-caret left-caret');
-		root.find('.sub-menu:visible').hide();
-	});
-});
+$(document).ready(function() {
+    $('.navbar a.dropdown-toggle').on('click', function(e) {
+        var $el = $(this);
+        var $parent = $(this).offsetParent(".dropdown-menu");
+        $(this).parent("li").toggleClass('open');
 
-$.extend( true, $.fn.dataTable.defaults, {
-    "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]],
-    "pageLength": -1
-  } );
+        if(!$parent.parent().hasClass('nav')) {
+            $el.next().css({"top": $el[0].offsetTop, "left": $parent.outerWidth() - 4});
+        }
+
+        $('.nav li.open').not($(this).parents("li")).removeClass("open");
+
+        return false;
+    });
+});
 </script>

--- a/expo/templates/menu.tmpl
+++ b/expo/templates/menu.tmpl
@@ -1,20 +1,18 @@
 {% load i18n menu_tags cache %}
 
 {% for child in children %}
-
-
-<li class="{% if child.ancestor %}ancestor{% endif %} {% if child.selected %}active{% endif %} {% if child.children %}dropdown{% endif %}">
-    {% if child.children %}<a class="dropdown-toggle trigger" data-toggle="dropdown" href="#">
-      {{ child.get_menu_title }} <span class="caret"></span>
+<li {% if child.selected %}class="active"{% endif %}>
+{% if child.children %}
+    <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+        {{ child.get_menu_title }} <b class="caret"></b>
     </a>
     <ul class="dropdown-menu">
         {% show_menu from_level to_level extra_inactive extra_active template "" "" child %}
     </ul>
-    {% else %}
-    <a href="{{ child.get_absolute_url }}"><span>{{ child.get_menu_title }}</span></a>
-    {% endif %}
+
+{% else %}
+    <a href="{{ child.get_absolute_url }}">{{ child.get_menu_title }}</a>
+{% endif %}
 </li>
 
-{% if class and forloop.last and not forloop.parentloop %}
-{% endif %}
 {% endfor %}


### PR DESCRIPTION
You can now click on a submenu, then click on a different submenu and
the old one will close, and the new one will open.

Sadly, this does NOT fix the mobile phone  menu problem.  What I did to customize the CSS way back when plays out VERY badly on smart devices.  

Because this offers a meaningful improvement, I’m pulling.  I intend to continue to fight the mobile  battle later.