### PR TITLE
GBE 997: URGENT - fix 500 error in download audio

### DIFF
--- a/expo/gbe/models/show.py
+++ b/expo/gbe/models/show.py
@@ -11,6 +11,7 @@ from gbe.models import (
 )
 from gbetext import cue_options
 from ticketing.functions import get_tickets
+import os as os
 
 
 class Show (Event):

--- a/expo/gbe/reporting/report_views.py
+++ b/expo/gbe/reporting/report_views.py
@@ -14,7 +14,7 @@ from gbe.ticketing_idd_interface import (
     get_checklist_items_for_tickets
     )
 
-import os
+import os as os
 import csv
 from reportlab.pdfgen import canvas
 # from gbe.reporting.view_techinfo import *

--- a/expo/tests/gbe/test_reports.py
+++ b/expo/tests/gbe/test_reports.py
@@ -545,3 +545,20 @@ class TestReports(TestCase):
         response = export_act_techinfo(request, context.show.eventitem_id)
         nt.assert_true(context.audio.notes in response.content)
         nt.assert_true('Center Spot' in response.content)
+
+    def test_download_tracks_for_show(self):
+        context = ActTechInfoContext(room_name="Theater")
+        context.show.scheduler_events.first()
+        reviewer = ProfileFactory()
+        grant_privilege(reviewer, "Tech Crew")
+        login_as(reviewer, self)
+        url = reverse(
+            'download_tracks_for_show',
+            urlconf='gbe.reporting.urls',
+            args=[context.show.eventitem_id])
+        response = self.client.get(url)
+        self.assertEquals(
+            response.get('Content-Disposition'),
+            str('attachment; filename="%s_%s.tar.gz"' % (
+                context.conference.conference_slug,
+                context.show.title.replace(' ', '_'))))


### PR DESCRIPTION
This is the clean fix for what I had to hot fix on the live site.  We definitely need this to be in master before the next push to live.

This includes:
- the two bug fixes needed to make download all tracks work on Special -> Report -> Summary of Act Tech Info -> pick a show -> choose download all audio (bottom of page)

- a unit test to catch the error - had we had this test, we wouldn’t have created these bugs in refactoring code.

It also happens to raise coverage to 93%  - :D

Should be pretty straight forward.
