### PR TITLE
GBE 971: delete users on user management page

### DIFF
--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -37,7 +37,7 @@ SITE_ID = 1
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [os.path.join(BASE_DIR, "templates"),],
+        'DIRS': [os.path.join(BASE_DIR, "templates"), ],
         'OPTIONS': {
             'loaders': (
                 'django.template.loaders.filesystem.Loader',

--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -173,7 +173,6 @@ THUMBNAIL_HIGH_RESOLUTION = True
 THUMBNAIL_PROCESSORS = (
     'easy_thumbnails.processors.colorspace',
     'easy_thumbnails.processors.autocrop',
-    'cmsplugin_nivoslider.thumbnail_processors.pad_image',
     'filer.thumbnail_processors.scale_and_crop_with_subject_location',
     'easy_thumbnails.processors.filters',
 )

--- a/expo/gbe/templates/gbe/profile_review.tmpl
+++ b/expo/gbe/templates/gbe/profile_review.tmpl
@@ -9,6 +9,10 @@
   <p class="vanilla">{{title}} </p>
   <h2 class="review-title">Manage Users</h2>
 
+  <p>This list includes only active users.  Inactive users can be viewed only
+  in the administration pages.  To reactivate a missing user, contact an
+  admin.</p>
+
   <div>Press the arrows to sort on a column.  To sort on an additional sub-order,
   press "Shift" to sort a secondary column.</div>
   <br/>

--- a/expo/gbe/urls.py
+++ b/expo/gbe/urls.py
@@ -21,6 +21,7 @@ from gbe.views import (
     CreateEventView,
     CreateVendorView,
     CreateVolunteerView,
+    DeleteProfileView,
     EditActView,
     EditActTechInfoView,
     EditClassView,
@@ -270,6 +271,9 @@ urlpatterns = patterns(
     url(r'^profile/admin/(\d+)/?$',
         AdminProfileView,
         name='admin_profile'),
+    url(r'^profile/delete/(\d+)/?$',
+        DeleteProfileView,
+        name='delete_profile'),
     url(r'^profile/landing_page/(\d+)/?$',
         LandingPageView,
         name='admin_landing_page')

--- a/expo/gbe/views/__init__.py
+++ b/expo/gbe/views/__init__.py
@@ -43,6 +43,7 @@ from edit_costume_view import EditCostumeView
 from review_class_list_view import ReviewClassListView
 from review_costume_list_view import ReviewCostumeListView
 from admin_profile_view import AdminProfileView
+from delete_profile_view import DeleteProfileView
 from update_profile_view import UpdateProfileView
 from logout_view import LogoutView
 from propose_class_view import ProposeClassView

--- a/expo/gbe/views/delete_profile_view.py
+++ b/expo/gbe/views/delete_profile_view.py
@@ -17,6 +17,7 @@ from gbetext import (
 )
 from django.shortcuts import get_object_or_404
 
+
 @login_required
 @log_func
 @never_cache

--- a/expo/gbe/views/delete_profile_view.py
+++ b/expo/gbe/views/delete_profile_view.py
@@ -60,6 +60,8 @@ def DeleteProfileView(request, profile_id):
             defaults={
                 'summary': "Update Profile Success",
                 'description': default_delete_profile_admin_msg})
-    deletion_summary = "Deleted %s<br><br>" % user_profile.user_object.username
-    messages.success(request, user_message[0].description)
+    deletion_summary = "Removed %s<br><br>\n%s" % (
+        user_profile.user_object.username,
+        user_message[0].description)
+    messages.success(request, deletion_summary)
     return return_page

--- a/expo/gbe/views/delete_profile_view.py
+++ b/expo/gbe/views/delete_profile_view.py
@@ -60,6 +60,6 @@ def DeleteProfileView(request, profile_id):
             defaults={
                 'summary': "Update Profile Success",
                 'description': default_delete_profile_admin_msg})
-    deletion_summary = "Deleted %s <br><br>" % user_profile.user_object.username
+    deletion_summary = "Deleted %s<br><br>" % user_profile.user_object.username
     messages.success(request, user_message[0].description)
     return return_page

--- a/expo/gbe/views/delete_profile_view.py
+++ b/expo/gbe/views/delete_profile_view.py
@@ -1,0 +1,64 @@
+from django.views.decorators.cache import never_cache
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from django.core.urlresolvers import reverse
+from expo.gbe_logging import log_func
+from gbe.models import (
+    Profile,
+    UserMessage,
+)
+from scheduler.models import ResourceAllocation
+from gbe.functions import validate_perms
+from gbetext import (
+    default_deactivate_profile_admin_msg,
+    default_delete_profile_admin_msg,
+)
+from django.shortcuts import get_object_or_404
+
+@login_required
+@log_func
+@never_cache
+def DeleteProfileView(request, profile_id):
+    admin_profile = validate_perms(request, ('Registrar',))
+    if profile_id:
+        user_profile = get_object_or_404(Profile, resourceitem_id=profile_id)
+    return_page = HttpResponseRedirect(reverse('manage_users',
+                                               urlconf='gbe.urls'))
+
+    bookings = ResourceAllocation.objects.filter(
+        resource__worker___item=user_profile).count()
+    if (bookings >= 1) or (
+            user_profile.personae.count() >= 1) or (
+            user_profile.contact.count() >= 1) or (
+            user_profile.volunteering.count() >= 1) or (
+            user_profile.costumes.count() >= 1) or (
+            user_profile.vendor_set.count() >= 1) or (
+            user_profile.bidevaluation_set.count() >= 1) or (
+            user_profile.actbidevaluation_set.count() >= 1) or (
+            user_profile.user_object.purchaser_set.count() >= 1):
+        user_profile.user_object.is_active = False
+        user_profile.user_object.save()
+        admin_page = "<a href='/admin/auth/user/%d/'>User Page</a>" % (
+            user_profile.user_object.pk
+        )
+        user_message = UserMessage.objects.get_or_create(
+            view='DeleteProfileView',
+            code="DEACTIVATE_PROFILE_ADMIN",
+            defaults={
+                'summary': "Update Profile Success",
+                'description':
+                    default_deactivate_profile_admin_msg + admin_page
+                })
+    else:
+        user_profile.user_object.delete()
+        user_message = UserMessage.objects.get_or_create(
+            view='DeleteProfileView',
+            code="DELETE_PROFILE_ADMIN",
+            defaults={
+                'summary': "Update Profile Success",
+                'description': default_delete_profile_admin_msg})
+
+    messages.success(request, user_message[0].description)
+    return return_page

--- a/expo/gbe/views/delete_profile_view.py
+++ b/expo/gbe/views/delete_profile_view.py
@@ -60,6 +60,6 @@ def DeleteProfileView(request, profile_id):
             defaults={
                 'summary': "Update Profile Success",
                 'description': default_delete_profile_admin_msg})
-
+    deletion_summary = "Deleted %s <br><br>" % user_profile.user_object.username
     messages.success(request, user_message[0].description)
     return return_page

--- a/expo/gbe/views/review_profiles_view.py
+++ b/expo/gbe/views/review_profiles_view.py
@@ -23,7 +23,7 @@ def ReviewProfilesView(request):
               'Last Login',
               'Contact Info',
               'Action']
-    profiles = Profile.objects.all()
+    profiles = Profile.objects.filter(user_object__is_active=True)
     rows = []
     for aprofile in profiles:
         bid_row = {}
@@ -44,6 +44,11 @@ def ReviewProfilesView(request):
                                 urlconf='gbe.urls',
                                 args=[aprofile.resourceitem_id]),
                  'text': "Update"}]
+            bid_row['actions'] += [
+                {'url': reverse('delete_profile',
+                                urlconf='gbe.urls',
+                                args=[aprofile.resourceitem_id]),
+                 'text': "Delete"}]
         bid_row['actions'] += [
             {'url': reverse(
                 'admin_landing_page',

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -327,3 +327,9 @@ or edit the existing act.'''
 no_profile_msg = '''Your profile is not complete, you must provide a first \
 and last name, a name we can use on your badge, and a phone number we can \
 use to notify you of changes to the schedule at run time.'''
+default_deactivate_profile_admin_msg = '''This user is involved in one or \
+more activities on this site.  To protect unintended changes, the user was \
+deactivated.  To delete, reactivate, or review the details, go to the admin: \
+'''
+default_delete_profile_admin_msg = '''No relevant site data found, this user \
+has been completely deleted'''

--- a/expo/tests/gbe/test_delete_profile.py
+++ b/expo/tests/gbe/test_delete_profile.py
@@ -1,0 +1,78 @@
+from django.test import TestCase
+from django.test import Client
+from django.core.urlresolvers import reverse
+from tests.factories.gbe_factories import (
+    PersonaFactory,
+    ProfileFactory,
+)
+from tests.functions.gbe_functions import (
+    grant_privilege,
+    login_as,
+)
+from gbe.models import Profile
+from tests.contexts.class_context import ClassContext
+
+class TestAdminProfile(TestCase):
+    '''Tests for admin_profile  view'''
+    view_name = 'delete_profile'
+
+    def setUp(self):
+        self.client = Client()
+        self.privileged_user = ProfileFactory().user_object
+        grant_privilege(self.privileged_user, 'Registrar')
+        self.deleted_profile = ProfileFactory()
+
+    def assert_deactivated(self, response, profile):
+        self.assertRedirects(response, reverse('manage_users',
+                                               urlconf='gbe.urls'))
+        self.assertNotIn(profile.display_name, response)
+        profile.user_object.refresh_from_db()
+        self.assertFalse(profile.user_object.is_active)
+
+    def test_admin_profile_no_such_profile(self):
+        no_such_id = Profile.objects.latest('pk').pk + 1
+        url = reverse(self.view_name,
+                      args=[no_such_id],
+                      urlconf="gbe.urls")
+        login_as(self.privileged_user, self)
+        response = self.client.get(url)
+        self.assertEqual(404, response.status_code)
+
+    def test_unauthorized_user(self):
+        url = reverse(self.view_name,
+                      args=[self.deleted_profile.pk],
+                      urlconf='gbe.urls')
+        login_as(ProfileFactory(), self)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_user(self):
+        url = reverse(self.view_name,
+                      args=[self.deleted_profile.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assertRedirects(response, reverse('manage_users',
+                                               urlconf='gbe.urls'))
+        self.assertNotIn(self.deleted_profile.display_name, response)
+        with self.assertRaises(Profile.DoesNotExist):
+            Profile.objects.get(pk=self.deleted_profile)
+
+    def test_deactivate_if_booked(self):
+        context = ClassContext()
+        teacher_prof = context.teacher.performer_profile
+        url = reverse(self.view_name,
+                      args=[teacher_prof.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assert_deactivated(response, teacher_prof)
+
+    def test_deactivate_if_persona(self):
+        persona_bearer = PersonaFactory()
+        url = reverse(self.view_name,
+                      args=[persona_bearer.performer_profile.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assert_deactivated(response, persona_bearer.performer_profile)

--- a/expo/tests/gbe/test_delete_profile.py
+++ b/expo/tests/gbe/test_delete_profile.py
@@ -2,8 +2,13 @@ from django.test import TestCase
 from django.test import Client
 from django.core.urlresolvers import reverse
 from tests.factories.gbe_factories import (
+    ActBidEvaluationFactory,
+    BidEvaluationFactory,
+    CostumeFactory,
     PersonaFactory,
     ProfileFactory,
+    VendorFactory,
+    VolunteerFactory,
 )
 from tests.functions.gbe_functions import (
     grant_privilege,
@@ -11,6 +16,8 @@ from tests.functions.gbe_functions import (
 )
 from gbe.models import Profile
 from tests.contexts.class_context import ClassContext
+from tests.factories.ticketing_factories import PurchaserFactory
+
 
 class TestAdminProfile(TestCase):
     '''Tests for admin_profile  view'''
@@ -76,3 +83,58 @@ class TestAdminProfile(TestCase):
         login_as(self.privileged_user, self)
         response = self.client.get(url, follow=True)
         self.assert_deactivated(response, persona_bearer.performer_profile)
+
+    def test_deactivate_if_volunteer(self):
+        volunteer = VolunteerFactory()
+        url = reverse(self.view_name,
+                      args=[volunteer.profile.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assert_deactivated(response, volunteer.profile)
+
+    def test_deactivate_if_costume(self):
+        costumer = CostumeFactory()
+        url = reverse(self.view_name,
+                      args=[costumer.profile.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assert_deactivated(response, costumer.profile)
+
+    def test_deactivate_if_vendor(self):
+        vendor = VendorFactory()
+        url = reverse(self.view_name,
+                      args=[vendor.profile.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assert_deactivated(response, vendor.profile)
+
+    def test_deactivate_if_bideval(self):
+        bid_eval = BidEvaluationFactory()
+        url = reverse(self.view_name,
+                      args=[bid_eval.evaluator.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assert_deactivated(response, bid_eval.evaluator)
+
+    def test_deactivate_if_actbideval(self):
+        bid_eval = BidEvaluationFactory()
+        url = reverse(self.view_name,
+                      args=[bid_eval.evaluator.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assert_deactivated(response, bid_eval.evaluator)
+
+    def test_deactivate_if_purchaser(self):
+        purchaser = PurchaserFactory(
+            matched_to_user=self.deleted_profile.user_object)
+        url = reverse(self.view_name,
+                      args=[self.deleted_profile.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        response = self.client.get(url, follow=True)
+        self.assert_deactivated(response, self.deleted_profile)

--- a/expo/tests/gbe/test_review_profiles_view.py
+++ b/expo/tests/gbe/test_review_profiles_view.py
@@ -24,7 +24,7 @@ class TestReviewProfiles(TestCase):
         self.privileged_user = ProfileFactory().user_object
         grant_privilege(self.privileged_user, 'Registrar')
         self.url = reverse('manage_users',
-                      urlconf='gbe.urls')
+                           urlconf='gbe.urls')
 
     def test_non_privileged_user(self):
         login_as(ProfileFactory(), self)

--- a/expo/tests/gbe/test_review_profiles_view.py
+++ b/expo/tests/gbe/test_review_profiles_view.py
@@ -49,3 +49,17 @@ class TestReviewProfiles(TestCase):
         assert self.profile.purchase_email in response.content
         assert self.profile.user_object.email in response.content
         assert self.profile.phone in response.content
+
+    def test_special_registrar(self):
+        login_as(self.privileged_user, self)
+        response = self.client.get(self.url)
+        self.assertIn("/profile/admin/", response.content)
+        self.assertIn("/profile/delete/", response.content)
+
+    def test_special_not_registrar(self):
+        coordinator = ProfileFactory().user_object
+        grant_privilege(coordinator, 'Volunteer Coordinator')
+        login_as(coordinator, self)
+        response = self.client.get(self.url)
+        self.assertNotIn("/profile/admin/", response.content)
+        self.assertNotIn("/profile/delete/", response.content)


### PR DESCRIPTION
On Special -> Manage -> Users
- there is a Delete option if you are a registrar
- it will either deactivate if there are related conference artifacts, or delete if this is really a user who did nothing with us.
- It gives an alert

There’s a lot of tests because there’s a giant if statement.