### PR TITLE
GBE-956: Add Google2 Recaptcha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ expo/gbe/static/mptt/draggable-admin.js
 expo/gbe/static/preview_images/admin-style.psd
 
 expo/gbe/static/sortedm2m/selector-search.gif
+
+random_docs/~$heduling API.docx

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -52,3 +52,4 @@ sqlparse==0.1.19
 jsonfield
 tablib
 diff-match-patch
+django-recaptcha2==1.0.0

--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -150,6 +150,7 @@ INSTALLED_APPS = (
     'cmsplugin_filer_link',
     'cmsplugin_filer_image',
     'cmsplugin_filer_teaser',
+    'snowpenguin.django.recaptcha2',
     'reversion',  # for versioning in cms -- use easy install
     'scheduler',
     'ticketing',

--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -159,7 +159,7 @@ class ProfileAdminForm(ParticipantForm):
 class UserCreateForm(UserCreationForm):
     required_css_class = 'required'
     error_css_class = 'error'
-    captcha = ReCaptchaField(widget=ReCaptchaWidget())
+    verification = ReCaptchaField(widget=ReCaptchaWidget())
     email = forms.EmailField(required=True)
     username = forms.CharField(label=username_label, help_text=username_help)
     first_name = forms.CharField(required=True)

--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -52,6 +52,7 @@ from snowpenguin.django.recaptcha2.fields import ReCaptchaField
 from snowpenguin.django.recaptcha2.widgets import ReCaptchaWidget
 from gbe.forms.common_queries import visible_personas
 
+
 time_start = 8 * 60
 time_stop = 24 * 60
 

--- a/expo/gbe/forms/remains.py
+++ b/expo/gbe/forms/remains.py
@@ -48,6 +48,8 @@ from gbe.functions import get_current_conference
 from django.shortcuts import get_object_or_404
 from django.core.exceptions import ValidationError
 from django.utils.formats import date_format
+from snowpenguin.django.recaptcha2.fields import ReCaptchaField
+from snowpenguin.django.recaptcha2.widgets import ReCaptchaWidget
 
 time_start = 8 * 60
 time_stop = 24 * 60
@@ -157,6 +159,7 @@ class ProfileAdminForm(ParticipantForm):
 class UserCreateForm(UserCreationForm):
     required_css_class = 'required'
     error_css_class = 'error'
+    captcha = ReCaptchaField(widget=ReCaptchaWidget())
     email = forms.EmailField(required=True)
     username = forms.CharField(label=username_label, help_text=username_help)
     first_name = forms.CharField(required=True)

--- a/expo/gbe/templates/gbe/register.tmpl
+++ b/expo/gbe/templates/gbe/register.tmpl
@@ -1,4 +1,9 @@
 {% extends 'base.tmpl' %}
+{% load recaptcha2 %}
+
+{% block head %}
+      {% recaptcha_init %}
+{% endblock %}
 
 {% block title %}
    Register For An Account

--- a/expo/templates/base.tmpl
+++ b/expo/templates/base.tmpl
@@ -35,7 +35,8 @@
 <!-- Latest compiled JavaScript -->
   <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
 
-
+  {% block head %}
+  {% endblock head %}
 
   </head>
   <body style="background-image: url({% static "img/curtains.jpeg" %})">

--- a/expo/tests/gbe/test_register.py
+++ b/expo/tests/gbe/test_register.py
@@ -9,6 +9,7 @@ from tests.functions.gbe_functions import (
     grant_privilege,
     login_as,
 )
+import os
 
 
 class TestRegister(TestCase):
@@ -18,6 +19,7 @@ class TestRegister(TestCase):
     def setUp(self):
         self.client = Client()
         self.counter = 0
+        os.environ['RECAPTCHA_DISABLE'] = 'True'
 
     def get_post_data(self):
         self.counter += 1
@@ -70,3 +72,6 @@ class TestRegister(TestCase):
         profile = ProfileFactory(user_object__email=post_data['email'])
         response = self.client.post(url, post_data, follow=True)
         self.assertIn("That email address is already in use", response.content)
+
+    def tearDown(self):
+        del os.environ['RECAPTCHA_DISABLE']


### PR DESCRIPTION
Adding the “I am not a robot” checkbox to the site.  Used this django plugin:

https://github.com/kbytesys/django-recaptcha2

Instructions to test:
- rebuild vagrant (aka, install the plugin)
- set this in your local host:

RECAPTCHA_PRIVATE_KEY = '6Le0dx0UAAAAACNZynxCx5mUovu3M1Au3XFeeFKN'
RECAPTCHA_PUBLIC_KEY = '6Le0dx0UAAAAAFGd_HJzX22FdzhwI-GCh8nCoXoU'

Your machine should read as 127.0.0.1 for this to work.  

These are our test keys and will ONLY work on your local…  the other keys are installed only on the servers.

Since this is a potentially annoying package install, I won’t pull it until I test this branch on the test site.  If there’s no comments, pulling to master and pushing to live will happen quickly after that.