### PR TITLE
GBE-2015: remove 'en' from language settings.

### DIFF
--- a/expo/expo/settings.py
+++ b/expo/expo/settings.py
@@ -70,8 +70,6 @@ CMS_TEMPLATES = (
 
 LANGUAGES = [
     ('en-us', gettext('en-us')),
-    ('en', gettext('en')),
-
 ]
 
 
@@ -333,13 +331,6 @@ CMS_LANGUAGES = {
             'code': 'en-us',
             'hide_untranslated': False,
             'name': gettext('en-us'),
-            'redirect_on_fallback': True,
-        },
-        {
-            'public': True,
-            'code': 'en',
-            'hide_untranslated': False,
-            'name': gettext('en'),
             'redirect_on_fallback': True,
         },
     ],


### PR DESCRIPTION
this is a several line change to settings.py.

Reran tests
pepdiff no changes
tested manually that server is OK locally and “en” is removed.
