### PR TITLE
GBE 1017: mail sent to ADMINS when on Debug

### DIFF
--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -67,6 +67,24 @@ def validate_perms(request, perms, require=True):
     return False               # or just return false if we're just checking
 
 
+def mail_send_gbe(to_list,
+                  from_address,
+                  template,
+                  context,
+                  priority='now'):
+    if settings.DEBUG:
+        to_list = []
+        for admin in settings.ADMINS:
+            to_list += [admin[1]]
+        
+    mail.send(to_list,
+              from_address,
+              template=template,
+              context=context,
+              priority=priority,
+              )
+        
+    
 def send_user_contact_email(name, from_address, message):
     subject = "EMAIL FROM GBE SITE USER %s" % name
     to_addresses = settings.USER_CONTACT_RECIPIENT_ADDRESSES
@@ -235,12 +253,11 @@ def send_bid_state_change_mail(
         name,
         "default_bid_status_change",
         action)
-    mail.send(
+    mail_send_gbe(
         email,
         template.sender.from_email,
         template=name,
         context=context,
-        priority='now',
     )
 
 
@@ -251,14 +268,13 @@ def send_schedule_update_mail(participant_type, profile):
         "volunteer_schedule_update",
         "A change has been made to your %s Schedule!" % (
                 participant_type))
-    mail.send(
+    mail_send_gbe(
         profile.contact_email,
         template.sender.from_email,
         template=name,
         context={
             'site': Site.objects.get_current().domain,
             'profile': profile},
-        priority='now',
     )
 
 
@@ -276,7 +292,7 @@ def notify_reviewers_on_bid_change(bidder,
         "%s %s Occurred" % (bid_type, action))
     to_list = [user.email for user in
                User.objects.filter(groups__name=group_name)]
-    mail.send(to_list,
+    mail_send_gbe(to_list,
               template.sender.from_email,
               template=name,
               context={
@@ -286,7 +302,6 @@ def notify_reviewers_on_bid_change(bidder,
                 'conference': conference,
                 'group_name': group_name,
                 'review_url': Site.objects.get_current().domain+review_url},
-              priority='now',
               )
 
 
@@ -304,14 +319,13 @@ def send_warnings_to_staff(bidder,
         if 'email' in warning:
             to_list += [warning['email']]
 
-    mail.send(to_list,
+    mail_send_gbe(to_list,
               template.sender.from_email,
               template=name,
               context={
                 'bidder': bidder,
                 'bid_type': bid_type,
                 'warnings': warnings},
-              priority='now',
               )
 
 

--- a/expo/gbe/functions.py
+++ b/expo/gbe/functions.py
@@ -76,15 +76,15 @@ def mail_send_gbe(to_list,
         to_list = []
         for admin in settings.ADMINS:
             to_list += [admin[1]]
-        
+
     mail.send(to_list,
               from_address,
               template=template,
               context=context,
               priority=priority,
               )
-        
-    
+
+
 def send_user_contact_email(name, from_address, message):
     subject = "EMAIL FROM GBE SITE USER %s" % name
     to_addresses = settings.USER_CONTACT_RECIPIENT_ADDRESSES
@@ -292,17 +292,18 @@ def notify_reviewers_on_bid_change(bidder,
         "%s %s Occurred" % (bid_type, action))
     to_list = [user.email for user in
                User.objects.filter(groups__name=group_name)]
-    mail_send_gbe(to_list,
-              template.sender.from_email,
-              template=name,
-              context={
-                'bidder': bidder,
-                'bid_type': bid_type,
-                'action': action,
-                'conference': conference,
-                'group_name': group_name,
-                'review_url': Site.objects.get_current().domain+review_url},
-              )
+    mail_send_gbe(
+        to_list,
+        template.sender.from_email,
+        template=name,
+        context={
+            'bidder': bidder,
+            'bid_type': bid_type,
+            'action': action,
+            'conference': conference,
+            'group_name': group_name,
+            'review_url': Site.objects.get_current().domain+review_url},
+        )
 
 
 def send_warnings_to_staff(bidder,
@@ -319,14 +320,15 @@ def send_warnings_to_staff(bidder,
         if 'email' in warning:
             to_list += [warning['email']]
 
-    mail_send_gbe(to_list,
-              template.sender.from_email,
-              template=name,
-              context={
-                'bidder': bidder,
-                'bid_type': bid_type,
-                'warnings': warnings},
-              )
+    mail_send_gbe(
+        to_list,
+        template.sender.from_email,
+        template=name,
+        context={
+            'bidder': bidder,
+            'bid_type': bid_type,
+            'warnings': warnings},
+        )
 
 
 def get_gbe_schedulable_items(confitem_type,

--- a/expo/tests/functions/gbe_functions.py
+++ b/expo/tests/functions/gbe_functions.py
@@ -163,6 +163,13 @@ def assert_email_template_used(
     assert msg.from_email == email
 
 
+def assert_email_recipient(to_list):
+    assert 1 == len(mail.outbox)
+    msg = mail.outbox[0]
+    for to_msg, to_test in zip(msg.to, to_list):
+        assert to_msg == to_test
+
+
 def assert_right_mail_right_addresses(
         queue_order,
         num_email,


### PR DESCRIPTION
When the system is set to debug, the email is sent to the ADMINS (the django setting), instead of the regular user.  This is a preventative on the wdbfactional test server - I need to test that the email system actually works end to end, but when the email is sent, I don’t want to freak out users.
