### PR TITLE
GBE-1021: fix bug in create event for classes

### DIFF
--- a/expo/gbe/views/create_event_view.py
+++ b/expo/gbe/views/create_event_view.py
@@ -25,6 +25,10 @@ def CreateEventView(request, event_type):
             event = form.save(commit=False)
             event.e_conference = Conference.objects.filter(
                 status='upcoming').first()
+            if event_type == "Class":
+                event.b_conference = event.e_conference
+                event.b_title = event.e_title
+                event.b_description = event.e_description
             event.save()
             return HttpResponseRedirect(reverse('event_schedule',
                                                 urlconf='scheduler.urls',

--- a/expo/tests/gbe/test_create_event.py
+++ b/expo/tests/gbe/test_create_event.py
@@ -131,3 +131,22 @@ class TestCreateEvent(TestCase):
         assert "Events Information" in response.content
         nt.assert_true(Class.objects.filter(
             e_title=data['e_title']).count() > 0)
+
+    def test_create_class_gbe_works_for_teacher(self):
+        url = reverse(
+            self.view_name,
+            args=['Class'],
+            urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        data = self.post_data('Class')
+        data['accepted'] = '3'
+        data['teacher'] = self.performer.pk
+        self.client.post(
+            url,
+            data=data,
+            follow=True)
+        # now make sure that home page is not broken
+        url = reverse('home', urlconf='gbe.urls')
+        login_as(self.performer.contact, self)
+        response = self.client.get(url)
+        self.assertContains(response, data['e_title'])


### PR DESCRIPTION
When I dug in, this was really a bug from the django 1.8 upgrade - when we separated b_* and e_*, we should have made sure that class create through scheduler included both parts, and not just e_* data.

Fixed that with a fast switch, and added a test