### PR TITLE
GBE-1013:  check validity of act tech

### DIFF
--- a/expo/gbe/views/edit_act_techinfo_view.py
+++ b/expo/gbe/views/edit_act_techinfo_view.py
@@ -160,11 +160,14 @@ def EditActTechInfoView(request, act_id):
 
         techforms = [lightingform,  audioform, stageform, ]
 
+        forms_valid = True
         for f in techforms:
-            if f.is_valid():
+            forms_valid = f.is_valid() and forms_valid
+        if forms_valid:
+            for f in techforms:
                 f.save()
         tech = act.tech
-        if tech.is_complete and not cue_fail:
+        if forms_valid and tech.is_complete and not cue_fail:
             user_message = UserMessage.objects.get_or_create(
                 view='EditActTechInfoView',
                 code="UPDATE_ACT_TECH",

--- a/expo/tests/gbe/test_edit_act_techinfo.py
+++ b/expo/tests/gbe/test_edit_act_techinfo.py
@@ -421,3 +421,23 @@ class TestEditActTechInfo(TestCase):
         self.assertEqual(response.status_code, 200)
         assert_alert_exists(
             response, 'success', 'Success', msg.description)
+
+    def test_edit_act_techinfo_form_invalid(self):
+        context = ActTechInfoContext(schedule_rehearsal=True)
+        another_rehearsal = context._schedule_rehearsal(context.sched_event)
+        url = reverse('act_techinfo_edit',
+                      urlconf='gbe.urls',
+                      args=[context.act.pk])
+        login_as(context.performer.contact, self)
+        data = self.get_full_post(
+            another_rehearsal,
+            context.show).copy()
+        data.update(self.get_cues(context.act.tech, 1))
+        data['stage_info-act_duration'] = 'bad no duration'
+        response = self.client.post(
+            url,
+            data=data,
+            follow=True)
+        self.assertContains(
+            response,
+            'Please enter your duration as mm:ss')


### PR DESCRIPTION
This checks the validity of the act tech forms *as a whole* then saves them all if the validity passes.  This keeps the user from saving partial data, only to get a failure, and it keeps us from silent failures by checking overall validity before declaring success.

pepdiff done
test added
runcoverage - same value of uncovered lines.