### PR TITLE
Fix ticket import for django 1.8

### DIFF
--- a/expo/transaction_cron_job.py
+++ b/expo/transaction_cron_job.py
@@ -19,8 +19,10 @@
 
 import sys
 import os
+import django
 sys.path.append('./expo')
 os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
+django.setup()
 
 from expo.gbe_logging import logger
 from django.conf import settings


### PR DESCRIPTION
recommended for django 1.8
wasn’t needed for 1.6

To test - you are best setting up a cron job.  Alternately, run python fro the command line. 

I recommend syncing against a copy of our DB, and deleting a transaction in ticketing, so that you know your ticket sync did something.