### PR TITLE
GBE 1034:  Bootstrapify the Update Profile Form

### DIFF
--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -775,7 +775,7 @@ td.form_label {
   width: 30%;
 }
 
-td.form_label>label {
+.form-group  > label > label {
   font-weight: normal;
 }
 
@@ -811,7 +811,7 @@ td.form_field.long_choice > ul > li
   height: 20px;
 }
 
-td.form_field > ul > li
+.form-group > ul > li
 {
   list-style-type: none;
 }

--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -175,6 +175,8 @@ h3.readonlyform
 .errorlist
 {
     color: red;
+    padding: 0;
+    font-weight: normal;
 }
 
 .how_volunteer
@@ -775,8 +777,12 @@ td.form_label {
   width: 30%;
 }
 
-td.form_label>label {
+.form-group  > div > div > div > label > label {
   font-weight: normal;
+}
+
+.form-group  > div > div > div > ul {
+  padding: 0;
 }
 
 td.form_field {
@@ -784,7 +790,11 @@ td.form_field {
   padding: 5px;
 }
 
-td.form_field.long_choice > ul 
+.form-horizontal .control-label {
+  text-align: left;
+}
+
+.long_choice > ul 
 {
   border-top: 1px solid black;
   -webkit-column-count: 2; /* Chrome, Safari, Opera */
@@ -811,7 +821,7 @@ td.form_field.long_choice > ul > li
   height: 20px;
 }
 
-td.form_field > ul > li
+.form-group > div > div > div > ul > li
 {
   list-style-type: none;
 }

--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -775,7 +775,7 @@ td.form_label {
   width: 30%;
 }
 
-.form-group  > label > label {
+td.form_label>label {
   font-weight: normal;
 }
 
@@ -811,7 +811,7 @@ td.form_field.long_choice > ul > li
   height: 20px;
 }
 
-.form-group > ul > li
+td.form_field > ul > li
 {
   list-style-type: none;
 }

--- a/expo/gbe/templates/gbe/update_profile.tmpl
+++ b/expo/gbe/templates/gbe/update_profile.tmpl
@@ -20,30 +20,29 @@ profile information. If you're teaching, the conference committee
 members and staff will be able to see your profile information,
 etc.).
 </p>
-
-
+ 
 <form method="POST" action="" enctype="multipart/form-data">
   {% for form in left_forms %}
     {% if form.errors %}
       <p style= "color:red"> There is an error on the form.  </p>
     {% endif %}
   {% endfor %}
-
-<div class="colmask">
-<div class = "left_col">
+<div class="container">
+<div class="row">
+<div class="col-md-6">
   {% for form in left_forms %}
     {% include "form_table.tmpl" %}
   {% endfor %}
-    <input type="submit" value="Update my account"> 
 </div>
-
-<div class = "right_col">
+<div class="col-md-6">
   {% for form in right_forms %}
   {%include "form_table.tmpl" %}
   {% endfor %}
 </div>
 </div>
-     
+</div>
+  <input type="submit" value="Update my account"> 
+
 </form>
 
 

--- a/expo/gbe/templates/gbe/update_profile.tmpl
+++ b/expo/gbe/templates/gbe/update_profile.tmpl
@@ -34,7 +34,7 @@ etc.).
     {% include "form_table.tmpl" %}
   {% endfor %}
 </div>
-<div class="col-md-6">
+<div class="col-md-4">
   {% for form in right_forms %}
   {%include "form_table.tmpl" %}
   {% endfor %}
@@ -44,6 +44,5 @@ etc.).
   <input type="submit" value="Update my account"> 
 
 </form>
-
 
 {% endblock %}

--- a/expo/templates/form_table.tmpl
+++ b/expo/templates/form_table.tmpl
@@ -13,52 +13,58 @@
 
   <font color="red">{{ form.non_field_errors }}</font>
 
-    <table class="gbe_table">
     {# Include the visible fields #}
     {% for field in form.visible_fields %}
-        <tr>
-            <td class="form_label">
-	      
-              {% if field.errors %}
+    <div class="form-group">
+	<div class="container">
+	<div class="row">
+	<div class="col-md-2">
+	<label for="field.name" class="control-label">	      
+            {% if field.errors %}
               <font color="red">!</font>&nbsp;&nbsp;
-	      {% elif field.css_classes == 'required' or field.name in submit_fields %}
+	    {% elif field.css_classes == 'required' or field.name in submit_fields %}
               <font color="red">*</font>
-              {% else %}
-               
-              {% endif %} 
-              {% if field.errors %}
+            {% endif %} 
+            {% if field.errors %}
                 <font color="red">
-              {% endif %}
-              {% if field.name in draft_fields %}
+            {% endif %}
+            {% if field.name in draft_fields %}
 	        <b>{{ field.label_tag }}</b>
-	      {% else %}
+	    {% else %}
 	        {{ field.label_tag }}
-	      {% endif %}
+	    {% endif %}
 
-              {% if field.errors %}
+            {% if field.errors %}
                 </font>
-              {% endif %} 
+            {% endif %} 
 
-              {% if field.help_text %}
+            {% if field.help_text %}
                 <span class="dropt" title="Help">
                 <img src= "{% static "img/question.png" %}" alt="?"/>
                   <span style="width:200px;float:right;text-align:left;">
                   {{ field.help_text }}
                   </span>
                 </span>
-              {% endif %}
-            </td>
-            <td class="form_field {% if field.field.choices|length > 7 %}long_choice{%endif%}">
-              {{ field }}
-            </td>
-          {% if field.errors %}
-	  <tr>
-	    <td>&nbsp;</td>
-            <td>
+            {% endif %}
+	</label>
+	</div>
+	<div class="col-md-4{% if field.field.choices|length > 7 %} long_choice{%endif%}">
+            {{ field }}
+	</div>
+	</div>
+	</div>
+        </div>
+
+      {% if field.errors %}
+	<div class="container">
+        <div class="row">
+	  <div class="col-md-2">&nbsp;</div>
+	  <div class="col-md-4">
+ 	    <label for="field.name">	      
               <font color="red">{{ field.errors }}</font>
-            </td>
-	  </tr>
-	  {% endif %}
-        </tr>
+            </label>
+	  </div>
+	</div>
+	</div>
+      {% endif %}
     {% endfor %}
-  </table>

--- a/expo/templates/form_table.tmpl
+++ b/expo/templates/form_table.tmpl
@@ -13,52 +13,49 @@
 
   <font color="red">{{ form.non_field_errors }}</font>
 
-    <table class="gbe_table">
+<div class="container">
     {# Include the visible fields #}
     {% for field in form.visible_fields %}
-        <tr>
-            <td class="form_label">
+    <div class="form-group">
+	<label for="field.name">
 	      
-              {% if field.errors %}
+            {% if field.errors %}
               <font color="red">!</font>&nbsp;&nbsp;
-	      {% elif field.css_classes == 'required' or field.name in submit_fields %}
+	    {% elif field.css_classes == 'required' or field.name in submit_fields %}
               <font color="red">*</font>
-              {% else %}
-               
-              {% endif %} 
-              {% if field.errors %}
+            {% else %}
+              &nbsp;
+            {% endif %} 
+            {% if field.errors %}
                 <font color="red">
-              {% endif %}
-              {% if field.name in draft_fields %}
+            {% endif %}
+            {% if field.name in draft_fields %}
 	        <b>{{ field.label_tag }}</b>
-	      {% else %}
+	    {% else %}
 	        {{ field.label_tag }}
-	      {% endif %}
-
-              {% if field.errors %}
+	    {% endif %}
+            {% if field.errors %}
                 </font>
-              {% endif %} 
+            {% endif %} 
 
-              {% if field.help_text %}
+            {% if field.help_text %}
                 <span class="dropt" title="Help">
                 <img src= "{% static "img/question.png" %}" alt="?"/>
                   <span style="width:200px;float:right;text-align:left;">
                   {{ field.help_text }}
                   </span>
                 </span>
-              {% endif %}
-            </td>
-            <td class="form_field {% if field.field.choices|length > 7 %}long_choice{%endif%}">
-              {{ field }}
-            </td>
-          {% if field.errors %}
-	  <tr>
-	    <td>&nbsp;</td>
-            <td>
+            {% endif %}
+	</label>
+        {{ field }}
+    {% if field.errors %}
+        <div class="row">
+	    <div class="col-md-2 form_label">&nbsp;</div>
+            <div class="col-md-4">
               <font color="red">{{ field.errors }}</font>
-            </td>
-	  </tr>
-	  {% endif %}
-        </tr>
+            </div>
+	</div>
+    {% endif %}
+    </div>
     {% endfor %}
-  </table>
+  </div>

--- a/expo/templates/form_table.tmpl
+++ b/expo/templates/form_table.tmpl
@@ -13,49 +13,52 @@
 
   <font color="red">{{ form.non_field_errors }}</font>
 
-<div class="container">
+    <table class="gbe_table">
     {# Include the visible fields #}
     {% for field in form.visible_fields %}
-    <div class="form-group">
-	<label for="field.name">
+        <tr>
+            <td class="form_label">
 	      
-            {% if field.errors %}
+              {% if field.errors %}
               <font color="red">!</font>&nbsp;&nbsp;
-	    {% elif field.css_classes == 'required' or field.name in submit_fields %}
+	      {% elif field.css_classes == 'required' or field.name in submit_fields %}
               <font color="red">*</font>
-            {% else %}
-              &nbsp;
-            {% endif %} 
-            {% if field.errors %}
+              {% else %}
+               
+              {% endif %} 
+              {% if field.errors %}
                 <font color="red">
-            {% endif %}
-            {% if field.name in draft_fields %}
+              {% endif %}
+              {% if field.name in draft_fields %}
 	        <b>{{ field.label_tag }}</b>
-	    {% else %}
+	      {% else %}
 	        {{ field.label_tag }}
-	    {% endif %}
-            {% if field.errors %}
-                </font>
-            {% endif %} 
+	      {% endif %}
 
-            {% if field.help_text %}
+              {% if field.errors %}
+                </font>
+              {% endif %} 
+
+              {% if field.help_text %}
                 <span class="dropt" title="Help">
                 <img src= "{% static "img/question.png" %}" alt="?"/>
                   <span style="width:200px;float:right;text-align:left;">
                   {{ field.help_text }}
                   </span>
                 </span>
-            {% endif %}
-	</label>
-        {{ field }}
-    {% if field.errors %}
-        <div class="row">
-	    <div class="col-md-2 form_label">&nbsp;</div>
-            <div class="col-md-4">
+              {% endif %}
+            </td>
+            <td class="form_field {% if field.field.choices|length > 7 %}long_choice{%endif%}">
+              {{ field }}
+            </td>
+          {% if field.errors %}
+	  <tr>
+	    <td>&nbsp;</td>
+            <td>
               <font color="red">{{ field.errors }}</font>
-            </div>
-	</div>
-    {% endif %}
-    </div>
+            </td>
+	  </tr>
+	  {% endif %}
+        </tr>
     {% endfor %}
-  </div>
+  </table>


### PR DESCRIPTION
#1034

I actually ended up affecting all the forms… for the better:
- put bootstrap containers around the two columns in Update Profile - now when the screen is small, the right side column goes below the left.
- put bootstrap columns in place of the table format in all forms using form_table.tmpl.  Layout on regular screen is largely the same, but on a small screen, the label is shown ABOVE the field.  That looks much better on a cell phone.

There’s more that can be done but this is a big improvement.