### PR TITLE
GBE-1014: fix bug on ticketing

### DIFF
--- a/expo/gbe/ticketing_idd_interface.py
+++ b/expo/gbe/ticketing_idd_interface.py
@@ -71,11 +71,11 @@ def verify_performer_app_paid(user_name, conference):
     from gbe.models import Act
     act_fees_purchased = 0
     acts_submitted = 0
-
     # First figure out how many acts this user has purchased
     for act_event in BrownPaperEvents.objects.filter(
             act_submission_event=True,
             conference=conference):
+
         for trans in Transaction.objects.all():
             trans_event = trans.ticket_item.ticket_id.split('-')[0]
             trans_user_name = trans.purchaser.matched_to_user.username
@@ -86,7 +86,9 @@ def verify_performer_app_paid(user_name, conference):
     # Then figure out how many acts have already been submitted.
     acts_submitted = Act.objects.filter(
         submitted=True,
-        b_conference=conference).count()
+        b_conference=conference,
+        performer__contact__user_object__username=user_name).count()
+
     logger.info("Purchased Count:  %s  Submitted Count:  %s" %
                 (act_fees_purchased, acts_submitted))
     return act_fees_purchased > acts_submitted
@@ -120,7 +122,8 @@ def verify_vendor_app_paid(user_name, conference):
     # Then figure out how many vendor applications have already been submitted.
     vendor_apps_submitted = Vendor.objects.filter(
         submitted=True,
-        b_conference=conference).count()
+        b_conference=conference,
+        profile__user_object__username=user_name).count()
     logger.info("Purchased Count:  %s  Submitted Count:  %s" %
                 (vendor_fees_purchased, vendor_apps_submitted))
     return vendor_fees_purchased > vendor_apps_submitted

--- a/expo/tests/gbe/test_create_act.py
+++ b/expo/tests/gbe/test_create_act.py
@@ -157,6 +157,14 @@ class TestCreateAct(TestCase):
         self.assertContains(response, "View</a> act")
         self.assertContains(response, data['theact-b_title'])
 
+    def test_act_submit_paid_act_w_other_acts_paid(self):
+        ActFactory(b_conference=self.current_conference,
+                   submitted=True)
+        response, data = self.post_paid_act_submission()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "View</a> act")
+        self.assertContains(response, data['theact-b_title'])
+
     def test_act_submit_paid_act_w_old_comp_act(self):
         prev_act = ActFactory(
             submitted=True,

--- a/expo/tests/gbe/test_create_vendor.py
+++ b/expo/tests/gbe/test_create_vendor.py
@@ -133,6 +133,14 @@ class TestCreateVendor(TestCase):
         self.assertContains(response, "(Click to view)")
         self.assertContains(response, data['thebiz-b_title'])
 
+    def test_create_paid_vendor_w_other_vendor_paid(self):
+        VendorFactory(b_conference=self.conference, submitted=True)
+        response, data = self.post_paid_vendor_submission()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("Profile View", response.content)
+        self.assertContains(response, "(Click to view)")
+        self.assertContains(response, data['thebiz-b_title'])
+
     def test_create_vendor_post_with_vendor_old_comp(self):
         comped_vendor = VendorFactory(
             submitted=True,

--- a/expo/tests/ticketing/test_transactions.py
+++ b/expo/tests/ticketing/test_transactions.py
@@ -86,11 +86,12 @@ class TestTransactions(TestCase):
         '''
         BrownPaperEvents.objects.all().delete()
         BrownPaperSettings.objects.all().delete()
-        event = BrownPaperEventsFactory()
+        BrownPaperSettingsFactory()
+        event = BrownPaperEventsFactory(bpt_event_id="1")
         ticket = TicketItemFactory(
             bpt_event=event,
             ticket_id='%s-%s' % (event.bpt_event_id, '3255985'))
-        BrownPaperSettingsFactory()
+
         limbo, created = User.objects.get_or_create(username='limbo')
 
         a = Mock()


### PR DESCRIPTION
only 1 person could ever submit, because the logic was “get all the submitted acts and compare them to what this person paid for.”

So after 1 person submits, the next person (who only bought 1 fee), can’t submit.  

The filter to check only for THIS user’s act submissions was washed away in a ticket update I made in Feb.

Fixed the bug in both acts and vendors, and then made tests to cover the back 