### PR TITLE
GBE 1039: Bootstrapify user landing page

### DIFF
--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -3,7 +3,6 @@ body {
   margin: 0px;
   border: 0px;
   padding: 0px;
-  font-family: Lucida Grande,Tahoma,Verdana,sans-serif;
 }
 
 
@@ -679,6 +678,61 @@ div.gbe-alert
 	left:73%;			/* Please make note of the brackets here:
 					(100% - left column width) plus (center column left and right padding) plus (left column left and right padding) plus (right column left padding) */
 }
+
+/* can remove above when we get rid of all 3 column templates in the old way, below is a nicer
+ * boostrap way that lets us revert to tabs when the screen size is small */
+/* small device */
+/* --------------- Responsive Fixes --------------- */
+/* small device */
+@media (max-width: 767px) {
+  .device-big {
+    display: none;
+  }
+  .device-small {
+    display: block;
+  }
+}
+
+.device-small > li:hover {
+  border-bottom: 4px solid #C78785;
+}
+
+.device-small > li.active {
+  border-bottom: 4px solid #8e0e0a;;
+  position: relative;
+}
+
+.device-small > li > a {
+  color: black;
+}
+  
+.device-small > li.active > a {
+  background-color: inherit;
+}
+
+.device-small > li.active > a:hover {
+  background-color: inherit;
+}
+
+.device-small > li.active > a > li:hover {
+  background-color: inherit;
+}
+
+/* big device */
+@media only screen and (min-width : 768px) {
+  .device-big, .tab-content > .tab-pane {
+    display: block;
+  }
+  .device-small {
+    display: none;
+  }
+  .tab-content > .tab-pane {
+    display: block;
+  }
+}
+/* --------------- / Responsive Fixes --------------- */
+
+
 .landing_box{
 	border: 1px solid black;
         padding: 10px;

--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -683,6 +683,13 @@ div.gbe-alert
  * boostrap way that lets us revert to tabs when the screen size is small */
 /* small device */
 /* --------------- Responsive Fixes --------------- */
+
+.three-column-container {
+  padding-right: 0px;
+  padding-left: 0px;
+  width:inherit
+}
+
 /* small device */
 @media (max-width: 767px) {
   .device-big {

--- a/expo/gbe/templates/gbe/landing_page.tmpl
+++ b/expo/gbe/templates/gbe/landing_page.tmpl
@@ -4,38 +4,46 @@
 {% endblock %}
 
 {% block content %}
+<div class="container">
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs device-small" role="tablist">
+        <li role="presentation" class="active">
+	  <a href="#news" aria-controls="home" role="tab" data-toggle="tab">News</a>
+	</li>
+        <li role="presentation">
+	  <a href="#on_site" aria-controls="profile" role="tab" data-toggle="tab">On Site</a>
+	</li>
+        <li role="presentation">
+	  <a href="#to-do" aria-controls="messages" role="tab" data-toggle="tab">To-Do List</a>
+	</li>
+    </ul>
 
-<div class="colmask threecol">
-     <div class="colmid">
-       <div class="colleft">
-         <div class="col1">
-            {% if profile and bookings %}
-                <div class='landing_box'>
-                  {% include 'gbe/incl_schedule.tmpl' %}
-        		    </div>
-  	        &nbsp;
-  	        {% endif %}
-
-            {% if profile and tickets %}
+    <!-- Tab panes -->
+    <div class="tab-content">
+        <div role="tabpanel" class="tab-pane active col col-xs-12 col-sm-3" id="news" style="padding: 4px">
+	  {% include 'gbe/incl_lp_left.tmpl' %}
+	</div>
+        <div role="tabpanel" class="tab-pane col-xs-12 col-sm-4" id="on_site" style="padding: 4px">
+	  {% if profile and bookings %}
+             <div class='landing_box'>
+               {% include 'gbe/incl_schedule.tmpl' %}
+             </div>
+  	     &nbsp;
+  	  {% endif %}
+          {% if profile and tickets %}
             <div class='landing_box'>
-        			 {% include 'gbe/incl_tickets.tmpl' %}
-    		    </div>
-    		    {% endif %}
-            {% include 'gbe/profile/incl_performer.tmpl' %}
-  	       </div>
-    	    <div class="col2">
-            {% include 'gbe/incl_lp_left.tmpl' %}
-          </div>
-        <div class="col3">
-            {% if profile %}
+               {% include 'gbe/incl_tickets.tmpl' %}
+    	    </div>
+    	  {% endif %}
+          {% include 'gbe/profile/incl_performer.tmpl' %}
+        </div>
+        <div role="tabpanel" class="tab-pane col-xs-12 col-sm-4" id="to-do" style="padding: 4px">
+	  {% if profile %}
             <div class='landing_box'>
                 {% include 'gbe/incl_lp_right.tmpl' %}
             </div>
-            {% endif %}
-	      </div>
-  	  </div>
-     </div>
+          {% endif %}
+	</div>
+    </div>
 </div>
-
-
 {% endblock %}

--- a/expo/gbe/templates/gbe/landing_page.tmpl
+++ b/expo/gbe/templates/gbe/landing_page.tmpl
@@ -4,7 +4,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container">
+<div class="container three-column-container">
     <!-- Nav tabs -->
     <ul class="nav nav-tabs device-small" role="tablist">
         <li role="presentation" class="active">
@@ -20,7 +20,7 @@
 
     <!-- Tab panes -->
     <div class="tab-content">
-        <div role="tabpanel" class="tab-pane active col col-xs-12 col-sm-3" id="news" style="padding: 4px">
+        <div role="tabpanel" class="tab-pane active col col-xs-12 col-sm-4" id="news" style="padding: 4px">
 	  {% include 'gbe/incl_lp_left.tmpl' %}
 	</div>
         <div role="tabpanel" class="tab-pane col-xs-12 col-sm-4" id="on_site" style="padding: 4px">

--- a/expo/templates/base.tmpl
+++ b/expo/templates/base.tmpl
@@ -8,10 +8,10 @@
     <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
     <link rel="stylesheet"
         type="text/css"
-        href= {% static "styles/base.css" %} media="all"/>
+        href= {% static "styles/gbe_bootstrap.min.css" %} media="all"/>
     <link rel="stylesheet"
         type="text/css"
-        href= {% static "styles/gbe_bootstrap.min.css" %} media="all"/>
+        href= {% static "styles/base.css" %} media="all"/>
     <link rel="stylesheet"
         type="text/css"
         href= {% static "styles/menus.css" %} media="all"/>


### PR DESCRIPTION
Used bootstrap to update the 3 column layout for this form.  It shouldn’t look too different on a desktop/laptop, but on a tablet/phone below ~760px, it will become 3 tabs instead of 3 columns, letting each column consume 100% of the space when the tab is selected.

I jiggered a bit with the look of the tabs in the hopes of it being clear that this area is lower than the main menu structure.