### PR TITLE
GBE 393: make feature acts

### DIFF
--- a/expo/gbe/admin.py
+++ b/expo/gbe/admin.py
@@ -172,6 +172,14 @@ class EmailTemplateSenderAdmin(admin.ModelAdmin):
     list_editable = ('from_email', )
     list_display_links = None
 
+class CastingAdmin(admin.ModelAdmin):
+    list_display = ('casting',
+                    'show_as_special',
+                    'display_order',)
+    list_editable = ('casting',
+                     'show_as_special',
+                     'display_order',)
+    list_display_links = None
 
 admin.site.register(Conference)
 admin.site.register(ConferenceDay, ConferenceDayAdmin)
@@ -207,3 +215,4 @@ admin.site.register(UserMessage, MessageAdmin)
 admin.site.register(ShowVote)
 admin.site.register(ActBidEvaluation)
 admin.site.register(EmailTemplateSender, EmailTemplateSenderAdmin)
+admin.site.register(ActCastingOption, CastingAdmin)

--- a/expo/gbe/admin.py
+++ b/expo/gbe/admin.py
@@ -172,6 +172,7 @@ class EmailTemplateSenderAdmin(admin.ModelAdmin):
     list_editable = ('from_email', )
     list_display_links = None
 
+
 class CastingAdmin(admin.ModelAdmin):
     list_display = ('casting',
                     'show_as_special',

--- a/expo/gbe/migrations/0007_actcastingoption.py
+++ b/expo/gbe/migrations/0007_actcastingoption.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gbe', '0006_act_is_summer'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ActCastingOption',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('casting', models.CharField(unique=True, max_length=50)),
+                ('show_as_special', models.BooleanField(default=True)),
+                ('display_order', models.IntegerField(unique=True)),
+            ],
+        ),
+    ]

--- a/expo/gbe/migrations/0009_actcastingoption.py
+++ b/expo/gbe/migrations/0009_actcastingoption.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('gbe', '0006_act_is_summer'),
+        ('gbe', '0008_remove_act_is_summer'),
     ]
 
     operations = [

--- a/expo/gbe/models/__init__.py
+++ b/expo/gbe/models/__init__.py
@@ -35,3 +35,4 @@ from bid_evaluation import BidEvaluation
 from show_vote import ShowVote
 from act_bid_evaluation import ActBidEvaluation
 from email_template_sender import EmailTemplateSender
+from act_casting_option import ActCastingOption

--- a/expo/gbe/models/act.py
+++ b/expo/gbe/models/act.py
@@ -137,18 +137,20 @@ class Act (Biddable, ActItem):
 
     @property
     def bid_review_summary(self):
-        show_name = ""
-        for show in self.get_scheduled_shows():
-            if len(show_name) > 0:
-                show_name += ", %s" % str(show.eventitem)
+        castings = ""
+        for (show, role) in self.get_castings():
+            if len(castings) > 0:
+                castings += ", %s" % (str(show.eventitem))
             else:
-                show_name = str(show.eventitem)
+                castings += str(show.eventitem)
+            if len(role) > 0:
+                castings += ' - %s' % role
 
         return (self.performer.name,
                 self.b_title,
                 self.updated_at.astimezone(pytz.timezone('America/New_York')),
                 acceptance_states[self.accepted][1],
-                show_name)
+                castings)
 
     @property
     def complete(self):

--- a/expo/gbe/models/act_casting_option.py
+++ b/expo/gbe/models/act_casting_option.py
@@ -13,4 +13,4 @@ class ActCastingOption(Model):
 
     class Meta:
         app_label = "gbe"
-        ordering = ["display_order",]
+        ordering = ["display_order", ]

--- a/expo/gbe/models/act_casting_option.py
+++ b/expo/gbe/models/act_casting_option.py
@@ -1,0 +1,16 @@
+from django.db.models import (
+    Model,
+    BooleanField,
+    IntegerField,
+    CharField,
+)
+
+
+class ActCastingOption(Model):
+    casting = CharField(max_length=50, unique=True)
+    show_as_special = BooleanField(default=True)
+    display_order = IntegerField(unique=True)
+
+    class Meta:
+        app_label = "gbe"
+        ordering = ["display_order",]

--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -393,6 +393,18 @@ td.describe
   color: #333333;
 }
 
+.perf-head
+{
+  font-family: "TwentiethCenturyPoster";
+  font-size: 30px;
+  color: white;
+}
+
+.perf-div
+{
+  background-color: #960320;
+}
+
 .listsubheader
 {
   font-family: Lucida Grande,Tahoma,Verdana,sans-serif;

--- a/expo/gbe/static/styles/gray_grids_css/main.css
+++ b/expo/gbe/static/styles/gray_grids_css/main.css
@@ -274,6 +274,14 @@
 .gray-bg {
   background: #f0f3f5;
 }
+
+@media (min-width:768px){#team .container{width:680px}
+}
+@media (min-width:992px){#team .container{width:900px}
+}
+@media (min-width:1200px){#team .container{width:1100px}
+}
+
 /* ==========================================================================
    Blog Section Style
    ========================================================================== */

--- a/expo/gbe/static/styles/gray_grids_css/main.css
+++ b/expo/gbe/static/styles/gray_grids_css/main.css
@@ -282,6 +282,13 @@
 @media (min-width:1200px){#team .container{width:1100px}
 }
 
+@media (min-width:768px){#team .team-desc{height:275px}
+}
+@media (min-width:992px){#team .team-desc{height:330px}
+}
+@media (min-width:1200px){#team .team-desc{height:400px}
+}
+
 /* ==========================================================================
    Blog Section Style
    ========================================================================== */

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -57,7 +57,7 @@ class ActChangeStateView(BidChangeStateView):
                     defaults={
                         'summary': "Casting Role Incorrect",
                         'description': no_casting_msg})
-                messages.warning(request, user_message[0].description)
+                messages.error(request, user_message[0].description)
 
                 return HttpResponseRedirect(reverse(
                     "act_review", urlconf='gbe.urls', args=[self.object.pk]))

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -25,6 +25,7 @@ from gbe.models import (
 from gbe.functions import send_bid_state_change_mail
 from gbetext import no_casting_msg
 
+
 class ActChangeStateView(BidChangeStateView):
     object_type = Act
     coordinator_permissions = ('Act Coordinator',)
@@ -48,8 +49,9 @@ class ActChangeStateView(BidChangeStateView):
         if self.act_accepted(request):
             # Cast the act into the show by adding it to the schedule
             # resource time
-            if (not 'casting' in request.POST) or (
-                    request.POST['casting'] != '' and ActCastingOption.objects.filter(
+            if ('casting' not in request.POST) or (
+                    request.POST[
+                        'casting'] != '' and ActCastingOption.objects.filter(
                         casting=request.POST['casting']).count() == 0):
                 user_message = UserMessage.objects.get_or_create(
                     view=self.__class__.__name__,

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -1,5 +1,10 @@
 from django.contrib import messages
-from django.shortcuts import get_object_or_404
+from django.shortcuts import (
+    get_object_or_404,
+    render,
+)
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
 from expo.gbe_logging import log_func
 from scheduler.models import (
     ActResource,
@@ -12,9 +17,13 @@ from expo.settings import (
     )
 from django.utils.formats import date_format
 from gbe.views import BidChangeStateView
-from gbe.models import Act
+from gbe.models import (
+    Act,
+    ActCastingOption,
+    UserMessage,
+)
 from gbe.functions import send_bid_state_change_mail
-
+from gbetext import no_casting_msg
 
 class ActChangeStateView(BidChangeStateView):
     object_type = Act
@@ -39,6 +48,19 @@ class ActChangeStateView(BidChangeStateView):
         if self.act_accepted(request):
             # Cast the act into the show by adding it to the schedule
             # resource time
+            if (not 'casting' in request.POST) or (
+                    request.POST['casting'] != '' and ActCastingOption.objects.filter(
+                        casting=request.POST['casting']).count() == 0):
+                user_message = UserMessage.objects.get_or_create(
+                    view=self.__class__.__name__,
+                    code="INVALID_CASTING",
+                    defaults={
+                        'summary': "Casting Role Incorrect",
+                        'description': no_casting_msg})
+                messages.warning(request, user_message[0].description)
+
+                return HttpResponseRedirect(reverse(
+                    "act_review", urlconf='gbe.urls', args=[self.object.pk]))
             casting = ResourceAllocation()
             casting.event = self.new_show
             actresource = ActResource(

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -41,7 +41,9 @@ class ActChangeStateView(BidChangeStateView):
             # resource time
             casting = ResourceAllocation()
             casting.event = self.new_show
-            actresource = ActResource(_item=self.object)
+            actresource = ActResource(
+                _item=self.object,
+                role=request.POST['casting'])
             actresource.save()
             for worker in self.object.get_performer_profiles():
                 conflicts = worker.get_conflicts(self.new_show)

--- a/expo/gbe/views/act_display_functions.py
+++ b/expo/gbe/views/act_display_functions.py
@@ -71,6 +71,7 @@ def get_act_form(act, form, header):
 
     return act_form
 
+
 def get_act_casting():
     castings = ActCastingOption.objects.all()
     cast_list = []

--- a/expo/gbe/views/act_display_functions.py
+++ b/expo/gbe/views/act_display_functions.py
@@ -6,6 +6,7 @@ from django.forms import (
 )
 from gbe.models import (
     Act,
+    ActCastingOption,
     UserMessage,
 )
 from gbetext import (
@@ -69,3 +70,14 @@ def get_act_form(act, form, header):
             label=act_bid_labels['video_choice'])
 
     return act_form
+
+def get_act_casting():
+    castings = ActCastingOption.objects.all()
+    cast_list = []
+    for casting in castings:
+        value = casting.casting
+        if not casting.show_as_special:
+            value = ''
+        cast_list += [(value, casting.casting)]
+
+    return cast_list

--- a/expo/gbe/views/review_act_view.py
+++ b/expo/gbe/views/review_act_view.py
@@ -1,5 +1,8 @@
 from django.core.urlresolvers import reverse
-from django.forms import ModelChoiceField
+from django.forms import (
+    ChoiceField,
+    ModelChoiceField,
+)
 from gbe.models import (
     Act,
     ActBidEvaluation,
@@ -14,6 +17,10 @@ from gbe.forms import (
 from gbe.views import ReviewBidView
 from gbe.views.functions import get_performer_form
 from gbe.views.act_display_functions import get_act_form
+from gbetext import (
+    act_casting_options,
+    act_casting_label,
+)
 
 
 class ReviewActView(ReviewBidView):
@@ -62,6 +69,10 @@ class ReviewActView(ReviewBidView):
             empty_label=None,
             label='Pick a Show',
             initial=start)
+        self.actionform.fields['casting'] = ChoiceField(
+            choices=act_casting_options,
+            required=False,
+            label=act_casting_label)
         self.actionURL = reverse(self.changestate_view_name,
                                  urlconf='gbe.urls',
                                  args=[act.id])

--- a/expo/gbe/views/review_act_view.py
+++ b/expo/gbe/views/review_act_view.py
@@ -17,9 +17,11 @@ from gbe.forms import (
 )
 from gbe.views import ReviewBidView
 from gbe.views.functions import get_performer_form
-from gbe.views.act_display_functions import get_act_form
+from gbe.views.act_display_functions import (
+    get_act_casting,
+    get_act_form,
+)
 from gbetext import (
-    act_casting_options,
     act_casting_label,
 )
 
@@ -76,7 +78,7 @@ class ReviewActView(ReviewBidView):
             label='Pick a Show',
             initial=start)
         self.actionform.fields['casting'] = ChoiceField(
-            choices=act_casting_options,
+            choices=get_act_casting(),
             required=False,
             label=act_casting_label,
             initial=casting)

--- a/expo/gbe/views/review_act_view.py
+++ b/expo/gbe/views/review_act_view.py
@@ -8,6 +8,7 @@ from gbe.models import (
     ActBidEvaluation,
     Show,
 )
+from scheduler.models import ActResource
 from gbe.forms import (
     ActBidEvaluationForm,
     ActEditForm,
@@ -60,6 +61,11 @@ class ReviewActView(ReviewBidView):
             scheduler_events__resources_allocated__resource__actresource___item=act).first()
         if not start:
             start = ""
+            casting = ""
+        else:
+            casting = ActResource.objects.filter(
+                allocations__event__eventitem=start,
+                _item=act).first().role
         q = Show.objects.filter(
             e_conference=act.b_conference,
             scheduler_events__isnull=False).order_by(
@@ -72,7 +78,8 @@ class ReviewActView(ReviewBidView):
         self.actionform.fields['casting'] = ChoiceField(
             choices=act_casting_options,
             required=False,
-            label=act_casting_label)
+            label=act_casting_label,
+            initial=casting)
         self.actionURL = reverse(self.changestate_view_name,
                                  urlconf='gbe.urls',
                                  args=[act.id])

--- a/expo/gbe/views/review_act_view.py
+++ b/expo/gbe/views/review_act_view.py
@@ -60,7 +60,8 @@ class ReviewActView(ReviewBidView):
 
         self.actionform = BidStateChangeForm(instance=act)
         start = Show.objects.filter(
-            scheduler_events__resources_allocated__resource__actresource___item=act).first()
+            scheduler_events__resources_allocated__resource__actresource___item=act
+            ).first()
         if not start:
             start = ""
             casting = ""

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -258,6 +258,9 @@ role_options = (('Teacher', "Teacher"),
                 ('Technical Director', "Technical Director"),
                 ('Producer', "Producer"))
 
+act_casting_options = (('Featured Performer', "Featured Performer"),
+                       ('Host', "Host"))
+
 vend_time_options = (
     (" ",
      " "),

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -258,8 +258,12 @@ role_options = (('Teacher', "Teacher"),
                 ('Technical Director', "Technical Director"),
                 ('Producer', "Producer"))
 
-act_casting_options = (('Featured Performer', "Featured Performer"),
-                       ('Host', "Host"))
+act_casting_options = (
+    ('', 'Regular act'),
+    ('Featured Performer', "Featured Performer"),
+    ('Host', "Host"))
+
+act_casting_label = "Special Display Selections"
 
 vend_time_options = (
     (" ",

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -263,12 +263,6 @@ role_options = (('Teacher', "Teacher"),
                 ('Technical Director', "Technical Director"),
                 ('Producer', "Producer"))
 
-act_casting_options = (
-    ('', 'Regular act'),
-    ('Featuring...', "Featuring..."),
-    ('Hosted By...', "Hosted By..."),
-    ('Returning Winner', "Returning Winner"))
-
 act_casting_label = "Section"
 
 vend_time_options = (

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -260,10 +260,11 @@ role_options = (('Teacher', "Teacher"),
 
 act_casting_options = (
     ('', 'Regular act'),
-    ('Featured Performer', "Featured Performer"),
-    ('Host', "Host"))
+    ('Featuring...', "Featuring..."),
+    ('Hosted By...', "Hosted By..."),
+    ('Returning Winner', "Returning Winner"))
 
-act_casting_label = "Special Display Selections"
+act_casting_label = "Section"
 
 vend_time_options = (
     (" ",

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -343,6 +343,8 @@ default_act_title_conflict = '''You've aready created a draft or made a \
 submission for this act.  View or edit that act here:  <a href="%s">%s</a>'''
 act_not_unique = '''Please name this act with a different title, \
 or edit the existing act.'''
+no_casting_msg = '''The casting role you've specified is not one our defined \
+roles.  Check the dropdown and try again.'''
 no_profile_msg = '''Your profile is not complete, you must provide a first \
 and last name, a name we can use on your badge, and a phone number we can \
 use to notify you of changes to the schedule at run time.'''

--- a/expo/scheduler/admin.py
+++ b/expo/scheduler/admin.py
@@ -72,6 +72,11 @@ class WorkerAdmin(admin.ModelAdmin):
     list_filter = ['role', '_item']
 
 
+class ActResourceAdmin(admin.ModelAdmin):
+    list_display = ('_item', 'role')
+    list_filter = ['role', '_item__act__b_conference']
+
+
 class OrderAdmin(admin.ModelAdmin):
     list_display = ('order', 'allocation')
 
@@ -87,5 +92,5 @@ admin.site.register(Resource)
 admin.site.register(ResourceAllocation, ResourceAllocationAdmin)
 admin.site.register(ActItem)
 admin.site.register(Ordering, OrderAdmin)
-admin.site.register(ActResource)
+admin.site.register(ActResource, ActResourceAdmin)
 admin.site.register(EventContainer, EventContainerAdmin)

--- a/expo/scheduler/migrations/0002_actresource_role.py
+++ b/expo/scheduler/migrations/0002_actresource_role.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('scheduler', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='actresource',
+            name='role',
+            field=models.CharField(blank=True, max_length=50, choices=[(b'Featured Performer', b'Featured Performer'), (b'Host', b'Host')]),
+        ),
+    ]

--- a/expo/scheduler/migrations/0002_actresource_role.py
+++ b/expo/scheduler/migrations/0002_actresource_role.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='actresource',
             name='role',
-            field=models.CharField(blank=True, max_length=50, choices=[(b'Featured Performer', b'Featured Performer'), (b'Host', b'Host')]),
+            field=models.CharField(max_length=50, blank=True),
         ),
     ]

--- a/expo/scheduler/models.py
+++ b/expo/scheduler/models.py
@@ -187,6 +187,17 @@ class ActItem(ResourceItem):
         except:
             return -1
 
+    def get_castings(self):
+        '''
+        Returns a list of all shows and cast roles this act is scheduled for.
+        '''
+        resources = ActResource.objects.filter(_item=self)
+        result = []
+        for resource in resources:
+            if resource.show:
+              result += [(resource.show, resource.role)]
+        return result
+
     def get_scheduled_shows(self):
         '''
         Returns a list of all shows this act is scheduled to appear in.

--- a/expo/scheduler/models.py
+++ b/expo/scheduler/models.py
@@ -247,6 +247,9 @@ class ActResource(Resource):
     '''
     objects = InheritanceManager()
     _item = models.ForeignKey(ActItem)
+    role = models.CharField(max_length=50,
+                            choices=act_casting_options,
+                            blank=True)
 
     @property
     def show(self):

--- a/expo/scheduler/models.py
+++ b/expo/scheduler/models.py
@@ -259,7 +259,6 @@ class ActResource(Resource):
     objects = InheritanceManager()
     _item = models.ForeignKey(ActItem)
     role = models.CharField(max_length=50,
-                            choices=act_casting_options,
                             blank=True)
 
     @property

--- a/expo/scheduler/models.py
+++ b/expo/scheduler/models.py
@@ -956,6 +956,12 @@ class Event(Schedulable):
 
         return bio_list
 
+    # get castings as in what acts have been booked for this event
+    @property
+    def casting_list(self):
+        return ActResource.objects.filter(allocations__event=self,
+                                          _item__act__accepted=3)
+
     def __str__(self):
         try:
             return self.eventitem.describe

--- a/expo/scheduler/models.py
+++ b/expo/scheduler/models.py
@@ -195,7 +195,7 @@ class ActItem(ResourceItem):
         result = []
         for resource in resources:
             if resource.show:
-              result += [(resource.show, resource.role)]
+                result += [(resource.show, resource.role)]
         return result
 
     def get_scheduled_shows(self):

--- a/expo/scheduler/templates/scheduler/event_detail.tmpl
+++ b/expo/scheduler/templates/scheduler/event_detail.tmpl
@@ -48,6 +48,10 @@
       {% endif %}
 
     </div>
+    {% if eventitem.featured_grid_list %}
+      {% include "featured_people.tmpl" with featured_items=eventitem.featured_grid_list%}
+    {% endif %}
+
     {% if eventitem.bio_grid_list %}
       {% include "people_gallery.tmpl" with heading="Check out our fabulous Performers!" grid_items=eventitem.bio_grid_list%}
 

--- a/expo/scheduler/views/functions.py
+++ b/expo/scheduler/views/functions.py
@@ -17,13 +17,22 @@ def get_event_display_info(eventitem_id):
     except EventItem.DoesNotExist:
         raise Http404
     bio_grid_list = []
+    featured_grid_list = []
     for sched_event in item.scheduler_events.all():
-        bio_grid_list += sched_event.bio_list
+        for casting in sched_event.casting_list:
+            if len(casting.role):
+                featured_grid_list += [{
+                    'bio': casting._item.bio,
+                    'role': casting.role,
+                    }]
+            else:
+                bio_grid_list += [casting._item.bio]
     eventitem_view = {'event': item,
                       'scheduled_events': item.scheduler_events.all().order_by(
                           'starttime'),
                       'labels': event_labels,
-                      'bio_grid_list': bio_grid_list
+                      'bio_grid_list': bio_grid_list,
+                      'featured_grid_list': featured_grid_list,
                       }
     return eventitem_view
 

--- a/expo/templates/featured_people.tmpl
+++ b/expo/templates/featured_people.tmpl
@@ -2,8 +2,8 @@
     <section id="team" class="section">
       <div class="container">
         <div class="row">
-          <div class="col-md-12">
-            <h2 class="section-title wow fadeInUp" data-wow-delay="0s">Special Guests</h2>
+          <div class="col-md-12 perf-div">
+            <h2 class="section-title perf-head fadeInUp" data-wow-delay="0s">Special Guests</h2>
           </div>
 {% for featured in featured_items %}
 {% cycle True True False False as img_right silent %}

--- a/expo/templates/featured_people.tmpl
+++ b/expo/templates/featured_people.tmpl
@@ -14,28 +14,37 @@
               <div class="team-desc">
                 <h3>{{featured.bio.name}}</h3>
                 <h5>{{featured.role}}</h5>
-                <p>{{featured.bio.bio | linebreaksbr}}</p>
+                <p>{{featured.bio.bio | truncatechars:200 }}</p>
               </div>
     {% endif %}
-              {% if featured.bio.promo_mini %}
+        {% if featured.bio.promo_mini %}
               <div class="team-img">
                 <img src="{{MEDIA_URL}}{{featured.bio.promo_mini}}" alt="">
                 <div class="social-icon">
-                  <a class="social" href="#" target="_blank"><i class="fa fa-facebook"></i></a>
-                  <a class="social" href="#" target="_blank"><i class="fa fa-twitter"></i></a>
-                  <a class="social" href="#" target="_blank"><i class="fa fa-linkedin"></i></a>
-                  <a class="social" href="#" target="_blank"><i class="fa fa-dribbble"></i></a>
-                  <a class="social" href="#" target="_blank"><i class="fa fa-behance"></i></a>
+            {% if featured.bio.promo_image %}
+                  <a class="social" href="{{MEDIA_URL}}{{featured.bio.promo_image}}">
+                    <i class="fa fa-eye"></i>
+                  </a>
+            {% endif %}
+            {% if featured.bio.homepage %}
+                  <a class="social" href="{{featured.bio.homepage}}" target="_blank">
+                    <i class="fa fa-link"></i>
+                  </a>
+            {% endif %}
+                  <a class="social" href="#" data-toggle="modal" data-target="#{{featured.bio.pk}}_modal" data-backdrop="true" >
+                    <i class="fa fa-external-link"></i>
+                  </a>
                 </div>
               </div>
-              {% endif %}
+        {% endif %}
     {% if not img_right %}
               <div class="team-desc">
                 <h3>{{featured.bio.name}}</h3>
                 <h5>{{featured.role}}</h5>
-                <p>{{featured.bio.bio | linebreaksbr}}</p>
+                <p>{{featured.bio.bio | truncatechars:200}}</p>
               </div>
     {% endif %}
+                {% include "people_modal.tmpl" with item=featured.bio %}
             </div>
           </div>
     {% cycle '' '</div>' '' '</div>' %}

--- a/expo/templates/featured_people.tmpl
+++ b/expo/templates/featured_people.tmpl
@@ -1,0 +1,48 @@
+    <!-- Featured Performer Section Start -->
+    <section id="team" class="section">
+      <div class="container">
+        <div class="row">
+          <div class="col-md-12">
+            <h2 class="section-title wow fadeInUp" data-wow-delay="0s">Featuring</h2>
+          </div>
+{% for featured in featured_items %}
+{% cycle True True False False as img_right silent %}
+    {% cycle '<div class="row">' '' '<div class="row">' '' %}
+          <div class="col-md-6 col-sm-12 col-xs-12">
+            <div class="single-member wow fadeInRight" data-wow-delay="0.2s">
+    {% if img_right %}
+              <div class="team-desc">
+                <h3>{{featured.bio.name}}</h3>
+                <h5>{{featured.role}}</h5>
+                <p>{{featured.bio.bio | linebreaksbr}}</p>
+              </div>
+    {% endif %}
+              {% if featured.bio.promo_mini %}
+              <div class="team-img">
+                <img src="{{MEDIA_URL}}{{featured.bio.promo_mini}}" alt="">
+                <div class="social-icon">
+                  <a class="social" href="#" target="_blank"><i class="fa fa-facebook"></i></a>
+                  <a class="social" href="#" target="_blank"><i class="fa fa-twitter"></i></a>
+                  <a class="social" href="#" target="_blank"><i class="fa fa-linkedin"></i></a>
+                  <a class="social" href="#" target="_blank"><i class="fa fa-dribbble"></i></a>
+                  <a class="social" href="#" target="_blank"><i class="fa fa-behance"></i></a>
+                </div>
+              </div>
+              {% endif %}
+    {% if not img_right %}
+              <div class="team-desc">
+                <h3>{{featured.bio.name}}</h3>
+                <h5>{{featured.role}}</h5>
+                <p>{{featured.bio.bio | linebreaksbr}}</p>
+              </div>
+    {% endif %}
+            </div>
+          </div>
+    {% cycle '' '</div>' '' '</div>' %}
+
+{% endfor %}
+
+        </div>
+      </div>
+    </section>
+    <!-- Featured Performers Section End -->

--- a/expo/templates/featured_people.tmpl
+++ b/expo/templates/featured_people.tmpl
@@ -3,7 +3,7 @@
       <div class="container">
         <div class="row">
           <div class="col-md-12">
-            <h2 class="section-title wow fadeInUp" data-wow-delay="0s">Featuring</h2>
+            <h2 class="section-title wow fadeInUp" data-wow-delay="0s">Special Guests</h2>
           </div>
 {% for featured in featured_items %}
 {% cycle True True False False as img_right silent %}
@@ -12,8 +12,8 @@
             <div class="single-member wow fadeInRight" data-wow-delay="0.2s">
     {% if img_right %}
               <div class="team-desc">
-                <h3>{{featured.bio.name}}</h3>
                 <h5>{{featured.role}}</h5>
+                <h3>{{featured.bio.name}}</h3>
                 <p>{{featured.bio.bio | truncatechars:200 }}</p>
               </div>
     {% endif %}
@@ -39,8 +39,8 @@
         {% endif %}
     {% if not img_right %}
               <div class="team-desc">
-                <h3>{{featured.bio.name}}</h3>
                 <h5>{{featured.role}}</h5>
+                <h3>{{featured.bio.name}}</h3>
                 <p>{{featured.bio.bio | truncatechars:200}}</p>
               </div>
     {% endif %}

--- a/expo/templates/people_gallery.tmpl
+++ b/expo/templates/people_gallery.tmpl
@@ -27,37 +27,7 @@
                   </a>
                 </div>
               </div>
-              <div class="modal fade" id="{{item.pk}}_modal" role="dialog">
-              <div class="modal-dialog">
-              <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal">&times;</button>
-                    <h4 class="modal-title">{{item.name}}</h4>
-                </div>
-                <div class="modal-body">
-                  <div class="row">
-                  {% if item.promo_image %}
-		      <div class="col-xs-6 col-xs-push-6">
-                         <a href="{{MEDIA_URL}}{{item.promo_image}}">
-		             <img src="{{MEDIA_URL}}{{item.promo_mini}}" alt="Photo" >
-		         </a>
-                      </div>
-                      <div class="col-xs-6 col-xs-pull-6">
-                  {% else %}
-                      <div class="col-xs-12">
-		  {%endif%}
-                      {{item.bio | linebreaksbr}}
-                  {% if item.homepage %}
- 		      <br><br>
-		      <b><a href="{{item.homepage}}" class="gallery_modal_icon"><i class="icon-link"></i>&nbsp;&nbsp; Website</a></b>
-	          {% endif %}
-                      </div>
-                  </div>
-                </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                </div>
-              </div></div></div>
+        {% include "people_modal.tmpl" %}
             </div>
 	</div>
         {% cycle '' '' '' '</div>' %}

--- a/expo/templates/people_gallery.tmpl
+++ b/expo/templates/people_gallery.tmpl
@@ -1,10 +1,12 @@
 
     <!-- Gallery Section Start -->
     <section id="gallery" class="section">
-      <div class="container">        
-        <div class="col-md-12">
-          <h2 class="section-title wow fadeInUp" data-wow-delay="0s">{{heading}}</h2>
+      <div class="container">
+      <div class="row">
+        <div class="col-md-12 perf-div">
+          <h2 class="section-title perf-head fadeInUp" data-wow-delay="0s">{{heading}}</h2>
         </div>
+      </div>
         <div class="gallery-wrap wow fadeInDown">
       {% for item in grid_items %}
         {% cycle '<div class="row">' '' '' '' %}

--- a/expo/templates/people_modal.tmpl
+++ b/expo/templates/people_modal.tmpl
@@ -1,0 +1,33 @@
+<!-- People Modal Start -->
+              <div class="modal fade" id="{{item.pk}}_modal" role="dialog">
+              <div class="modal-dialog">
+              <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal">&times;</button>
+                    <h4 class="modal-title">{{item.name}}</h4>
+                </div>
+                <div class="modal-body">
+                  <div class="row">
+                  {% if item.promo_image %}
+		      <div class="col-xs-6 col-xs-push-6">
+                         <a href="{{MEDIA_URL}}{{item.promo_image}}">
+		             <img src="{{MEDIA_URL}}{{item.promo_mini}}" alt="Photo" >
+		         </a>
+                      </div>
+                      <div class="col-xs-6 col-xs-pull-6">
+                  {% else %}
+                      <div class="col-xs-12">
+		  {%endif%}
+                      {{item.bio | linebreaksbr}}
+                  {% if item.homepage %}
+ 		      <br><br>
+		      <b><a href="{{item.homepage}}" class="gallery_modal_icon"><i class="icon-link"></i>&nbsp;&nbsp; Website</a></b>
+	          {% endif %}
+                      </div>
+                  </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+              </div></div></div>
+<!-- People Modal End -->

--- a/expo/tests/contexts/act_techinfo_context.py
+++ b/expo/tests/contexts/act_techinfo_context.py
@@ -24,7 +24,8 @@ class ActTechInfoContext():
                  conference=None,
                  room_name=None,
                  cue_count=1,
-                 schedule_rehearsal=False):
+                 schedule_rehearsal=False,
+                 act_role=""):
         self.conference = conference or ConferenceFactory()
         self.performer = performer or PersonaFactory()
         self.act = act or ActFactory(performer=self.performer,
@@ -48,7 +49,7 @@ class ActTechInfoContext():
         # schedule the act into the show
         ResourceAllocationFactory(
             event=self.sched_event,
-            resource=ActResourceFactory(_item=self.act.actitem_ptr))
+            resource=ActResourceFactory(_item=self.act.actitem_ptr, role=act_role))
         if schedule_rehearsal:
             self.rehearsal = self._schedule_rehearsal(
                 self.sched_event,

--- a/expo/tests/contexts/act_techinfo_context.py
+++ b/expo/tests/contexts/act_techinfo_context.py
@@ -49,7 +49,9 @@ class ActTechInfoContext():
         # schedule the act into the show
         ResourceAllocationFactory(
             event=self.sched_event,
-            resource=ActResourceFactory(_item=self.act.actitem_ptr, role=act_role))
+            resource=ActResourceFactory(
+                _item=self.act.actitem_ptr,
+                role=act_role))
         if schedule_rehearsal:
             self.rehearsal = self._schedule_rehearsal(
                 self.sched_event,

--- a/expo/tests/contexts/show_context.py
+++ b/expo/tests/contexts/show_context.py
@@ -26,7 +26,8 @@ class ShowContext:
                  performer=None,
                  conference=None,
                  room=None,
-                 starttime=None):
+                 starttime=None,
+                 act_role=''):
         self.performer = performer or PersonaFactory()
         self.conference = conference or ConferenceFactory()
         if not self.conference.conferenceday_set.exists():
@@ -42,7 +43,7 @@ class ShowContext:
         self.sched_event = None
         self.sched_event = self.schedule_instance(room=self.room,
                                                   starttime=starttime)
-        self.book_act(act)
+        self.book_act(act, act_role)
 
     def schedule_instance(self,
                           starttime=None,
@@ -65,13 +66,13 @@ class ShowContext:
             resource=LocationFactory(_item=room.locationitem_ptr))
         return sched_event
 
-    def book_act(self, act=None):
+    def book_act(self, act=None, act_role=''):
         act = act or ActFactory(b_conference=self.conference,
                                 accepted=3,
                                 submitted=True)
         booking = ResourceAllocationFactory(
             event=self.sched_event,
-            resource=ActResourceFactory(_item=act))
+            resource=ActResourceFactory(_item=act, role=act_role))
         return (act, booking)
 
     def order_act(self, act, order):

--- a/expo/tests/factories/gbe_factories.py
+++ b/expo/tests/factories/gbe_factories.py
@@ -178,6 +178,13 @@ class CueInfoFactory(DjangoModelFactory):
     sound_note = "sound_note field for test CueInfo object"
 
 
+class ActCastingOptionFactory(DjangoModelFactory):
+    class Meta:
+        model = conf.ActCastingOption
+    casting = "Hosted by..."
+    display_order = 0
+
+
 class ActFactory(DjangoModelFactory):
     class Meta:
         model = conf.Act

--- a/expo/tests/gbe/test_act_changestate.py
+++ b/expo/tests/gbe/test_act_changestate.py
@@ -90,7 +90,8 @@ class TestActChangestate(TestCase):
             starttime=self.context.sched_event.starttime)
         ResourceAllocationFactory(
             event=conflict,
-            resource=WorkerFactory(_item=self.context.performer.performer_profile)
+            resource=WorkerFactory(
+                _item=self.context.performer.performer_profile)
         )
         url = reverse(self.view_name,
                       args=[self.context.act.pk],
@@ -155,7 +156,8 @@ class TestActChangestate(TestCase):
         response = self.client.post(url, data=self.data)
         assert_email_template_used(
             "test template", "actemail@notify.com")
-        assert_email_recipient([(self.context.performer.contact.contact_email)])
+        assert_email_recipient([(
+            self.context.performer.contact.contact_email)])
 
     @override_settings(ADMINS=[('Admin', 'admin@mock.test')])
     @override_settings(DEBUG=True)
@@ -223,4 +225,3 @@ class TestActChangestate(TestCase):
             ActResource.objects.get(_item=self.context.act)
         assert_alert_exists(
             response, 'danger', 'Error', no_casting_msg)
-

--- a/expo/tests/gbe/test_review_act.py
+++ b/expo/tests/gbe/test_review_act.py
@@ -266,4 +266,5 @@ class TestReviewAct(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,
-            '<option value="Hosted by..." selected="selected">Hosted by...</option>')
+            '<option value="Hosted by..." selected="selected"' +
+            '>Hosted by...</option>')

--- a/expo/tests/gbe/test_review_act.py
+++ b/expo/tests/gbe/test_review_act.py
@@ -3,8 +3,10 @@ from django.core.exceptions import PermissionDenied
 import nose.tools as nt
 from django.test import TestCase
 from django.test import Client
+from tests.contexts import ActTechInfoContext
 from tests.factories.gbe_factories import (
     ActBidEvaluationFactory,
+    ActCastingOptionFactory,
     ActFactory,
     ConferenceFactory,
     PersonaFactory,
@@ -51,6 +53,17 @@ class TestReviewAct(TestCase):
         if invalid:
             del(data['bid'])
         return data
+
+    def get_act_w_roles(self, act):
+        ActCastingOptionFactory(casting="Regular Act",
+                                show_as_special=False,
+                                display_order=0)
+        ActCastingOptionFactory(display_order=1)
+        url = reverse('act_review',
+                      urlconf='gbe.urls',
+                      args=[act.pk])
+        login_as(self.privileged_user, self)
+        return self.client.get(url)
 
     def test_review_act_all_well(self):
         act = ActFactory()
@@ -230,3 +243,27 @@ class TestReviewAct(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertTrue('The Summer Act' in response.content)
+
+    def test_review_default_role_present(self):
+        act = ActFactory()
+        response = self.get_act_w_roles(act)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<option value="" selected="selected">Regular Act</option>')
+
+    def test_review_special_role_present(self):
+        act = ActFactory()
+        response = self.get_act_w_roles(act)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<option value="Hosted by...">Hosted by...</option>')
+
+    def test_review_special_role_already_cast(self):
+        context = ActTechInfoContext(act_role="Hosted by...")
+        response = self.get_act_w_roles(context.act)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            '<option value="Hosted by..." selected="selected">Hosted by...</option>')

--- a/expo/tests/gbe/test_review_act_list.py
+++ b/expo/tests/gbe/test_review_act_list.py
@@ -5,6 +5,7 @@ from django.test.client import RequestFactory
 from django.test import Client
 from tests.factories.gbe_factories import (
     ActBidEvaluationFactory,
+    ActCastingOptionFactory,
     ActFactory,
     ConferenceFactory,
     PersonaFactory,
@@ -88,6 +89,15 @@ class TestReviewActList(TestCase):
             data={'conf_slug': context.conference.conference_slug})
         assert context.acts[0].b_title in response.content
         assert context.show.e_title in response.content
+
+    def test_review_act_assigned_show_role(self):
+        context = ShowContext(act_role="Hosted By...")
+        login_as(self.privileged_user, self)
+        response = self.client.get(
+            self.url,
+            data={'conf_slug': context.conference.conference_slug})
+        assert context.show.e_title in response.content
+        assert "Hosted By..." in response.content
 
     def test_review_act_assigned_two_shows(self):
         context = ShowContext()

--- a/expo/tests/scheduler/test_detail_view.py
+++ b/expo/tests/scheduler/test_detail_view.py
@@ -1,5 +1,4 @@
 from django.core.urlresolvers import reverse
-from django.core.exceptions import PermissionDenied
 from tests.factories.gbe_factories import (
     ProfileFactory,
     ShowFactory,
@@ -13,43 +12,60 @@ from django.test import (
     Client,
     TestCase,
 )
+from tests.contexts import ActTechInfoContext
+from gbe.models import Conference
+from scheduler.models import EventItem
+from tests.functions.gbe_functions import bad_id_for
 
 
 class TestDetailView(TestCase):
     view_name = 'detail_view'
 
     def setUp(self):
+        Conference.objects.all().delete()
         self.client = Client()
-        self.show = ShowFactory()
-        self.sched_event = SchedEventFactory.create(
-            eventitem=self.show.eventitem_ptr)
-        self.url = reverse(self.view_name,
-                      urlconf="scheduler.urls",
-                      args=[self.sched_event.pk])
+        self.context = ActTechInfoContext()
+        self.url = reverse(
+            self.view_name,
+            urlconf="scheduler.urls",
+            args=[self.context.show.pk])
 
     def test_no_permission_required(self):
         response = self.client.get(self.url)
         self.assertEqual(200, response.status_code)
-        self.assertContains(response, self.show.e_title)
-
+        self.assertContains(response, self.context.show.e_title)
 
     def test_bad_id_raises_404(self):
         bad_url = reverse(self.view_name,
                       urlconf="scheduler.urls",
-                      args=[self.sched_event.pk+1])
+                      args=[bad_id_for(EventItem)])
         response = self.client.get(bad_url)
         self.assertEqual(response.status_code, 404)
 
     def test_repeated_lead_shows_once(self):
-        sched_event2 = SchedEventFactory.create(
-            eventitem=self.show.eventitem_ptr)
-        sched_events = [self.sched_event, sched_event2]
+        show = ShowFactory()
+        sched_events = [
+            SchedEventFactory.create(
+                eventitem=show.eventitem_ptr) for i in range(2)]
         staff_lead = ProfileFactory()
         lead_worker = WorkerFactory(_item=staff_lead.workeritem_ptr,
                                     role="Staff Lead")
         for se in sched_events:
             ResourceAllocationFactory.create(event=se,
                                              resource=lead_worker)
-        response = self.client.get(self.url)
+        response = self.client.get(reverse(
+            self.view_name,
+            urlconf="scheduler.urls",
+            args=[show.eventitem.pk]))
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, response.content.count(staff_lead.display_name))
+
+    def test_bio_grid(self):
+        self.context.performer.homepage = "www.testhomepage.com"
+        self.context.performer.save()
+        url = reverse(self.view_name,
+                      urlconf="scheduler.urls",
+                      args=[self.context.show.pk])
+        response = self.client.get(url)
+        self.assertEqual(200, response.status_code)
+        self.assertContains(response, self.context.performer.homepage)

--- a/expo/tests/scheduler/test_detail_view.py
+++ b/expo/tests/scheduler/test_detail_view.py
@@ -37,9 +37,10 @@ class TestDetailView(TestCase):
         self.assertContains(response, self.context.show.e_title)
 
     def test_bad_id_raises_404(self):
-        bad_url = reverse(self.view_name,
-                      urlconf="scheduler.urls",
-                      args=[bad_id_for(EventItem)])
+        bad_url = reverse(
+            self.view_name,
+            urlconf="scheduler.urls",
+            args=[bad_id_for(EventItem)])
         response = self.client.get(bad_url)
         self.assertEqual(response.status_code, 404)
 


### PR DESCRIPTION
- Scratch can define what types of roles a given act fills, le host, feature act, etc. with an admin switch
- act coordinator can “cast” the act into one of these roles in the act review pages.
- the act review table shows the casting as a nice FYI.
- the featured acts of any special type get their own grid display in the event detail view.

This requires a migrate in gbe & scheduler

To use, it has to be manually seeded with feature acts.

#393 