### PR TITLE
GBE-1056: Fix look of non-shows in event details

### DIFF
--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -474,6 +474,18 @@ td.describe
     margin: 10px;
     padding: 10px;
 }
+
+@media (min-width:768px){.bio_block {width:680px}
+}
+@media (min-width:992px){.bio_block {width:900px}
+}
+@media (min-width:1200px){.bio_block {width:1100px}
+}
+
+.bio_row
+{
+  padding-top: 10px;
+}
 .sched_detail_title
 {
   color: #333333;
@@ -517,12 +529,7 @@ td.describe
 {
  font-weight: bold;
 }
-.sched_bio_image
-{
-  width: 300px;
-  margin: 3px;
-  display: inline-block;
-}
+
 div.performer
 {
 }
@@ -552,18 +559,7 @@ div.performer
   vertical-align: middle;
   word-wrap:break-word;
 }
-.bio_image_block
-{
-  width: 28%;
-  text-align:right;
-  display: inline-block;
-}
-.bio_words
-{
-  width: 45%;
-  display: inline-block;
-  vertical-align: top;
-}
+
 .bio_name
 {
   margin: 10px 0px;

--- a/expo/scheduler/templates/scheduler/event_detail.tmpl
+++ b/expo/scheduler/templates/scheduler/event_detail.tmpl
@@ -52,41 +52,44 @@
       {% include "people_gallery.tmpl" with heading="Check out our fabulous Performers!" grid_items=eventitem.bio_grid_list%}
 
     {% elif eventitem.event.roles %}
-    <div class="bio_block font_regular">
+    <div class="bio_block font_regular container">
       {% for worker in eventitem.event.roles %}
-      {% ifchanged worker.workeritem %}
-      <div class="bio_words">
-	{%if worker.role == "Staff Lead"%}
-	  <h2 class="bio_name subtitle">{{worker.role}} - {{worker.workeritem}}</h2>
-        {%else%}
-          <h2 class="subtitle">About the {{worker.role}} - {{worker.workeritem.name}}</h2>
-          {{worker.workeritem.bio |linebreaksbr}}
-	{%endif%}
-      <br><br>
-      </div>
+      <div class="row bio_row">
+        {% ifchanged worker.workeritem %}
+        <div class="col-md-9 col-sm-8 col-xs-12">
+  	  {%if worker.role == "Staff Lead"%}
+	    <h2 class="bio_name subtitle">{{worker.role}} - {{worker.workeritem}}</h2>
+          {%else%}
+            <h2 class="subtitle">About the {{worker.role}} - {{worker.workeritem.name}}</h2>
+            {{worker.workeritem.bio |linebreaksbr}}
+	  {%endif%}
+        <br><br>
+        </div>
         {% if worker.workeritem.promo_mini %}
-          <div class="bio_name bio_image_block">
-          <img src="{{MEDIA_URL}}{{worker.workeritem.promo_mini}}" class="sched_bio_image">
+          <div class="col-md-3 col-sm-4 col-xs-12">
+          <img src="{{MEDIA_URL}}{{worker.workeritem.promo_mini}}">
           </div>
         {% endif %}
       {%endifchanged%}
+      </div>
       {% endfor %}
-    </div>
+      </div>
     {% elif eventitem.event.bios %}
-    <div class="bio_block font_regular">
+    <div class="bio_block font_regular container">
       {% for bio in eventitem.event.bios %}
-      <div class="bio_words">
+      <div class="row bio_row">
+        <div class="col-md-9 col-sm-8 col-xs-12">
         <h2 class="bio_name subtitle">About {{bio.name}}</h2>
         {{bio.bio |linebreaksbr}}
         <br><br>
-	
-      </div>
+        </div>
 
        {% if bio.promo_mini %}
-          <div class="bio_image_block">
-            <img src="{{MEDIA_URL}}{{bio.promo_mini}}" class="sched_bio_image">
+          <div class="col-md-3 col-sm-4 col-xs-12">
+            <img src="{{MEDIA_URL}}{{bio.promo_mini}}">
           </div>
         {% endif %}
+      </div>
       {% endfor %}
     </div>
     {% endif %}


### PR DESCRIPTION
This is all templates and CSS

#1056 

There are two things to test:
- a just-accepted class with no schedule details
- a scheduled class

They are built differently, but should render the same.

May need some fussy checking when the other pull request is merged.