### PR TITLE
GBE 1080: make ticket names be event names

### DIFF
--- a/expo/templates/ticket_link.tmpl
+++ b/expo/templates/ticket_link.tmpl
@@ -1,5 +1,3 @@
-{% load ticketing_filters %}
-
       <div class="tickets">
 	<br>
 	<b>Buy any of these tickets to get into this great event!</b><br>

--- a/expo/templates/ticket_link.tmpl
+++ b/expo/templates/ticket_link.tmpl
@@ -4,10 +4,10 @@
 	<br>
 	<b>Buy any of these tickets to get into this great event!</b><br>
 	<ul class="ticket_list"></ul>
-	{% for key, ticket in tickets.items %}
+	{% for ticket in tickets %}
 	  <li class="ticket_list_item">
 	    <span class="ticket_name">{{ ticket.title }}</span> - 
-	    <a href="http://www.brownpapertickets.com/event/ID-{{ user_id }}/{{ ticket.ticket_id|bpt_event }}/" target="_blank" class="ticket_link">
+	    <a href="http://www.brownpapertickets.com/event/ID-{{ user_id }}/{{ ticket.bpt_event_id }}/" target="_blank" class="ticket_link">
             Buy it now!
             </a>
 	  </li>

--- a/expo/tests/gbe/test_get_tickets.py
+++ b/expo/tests/gbe/test_get_tickets.py
@@ -12,12 +12,14 @@ from tests.factories.ticketing_factories import (
     BrownPaperEventsFactory,
     TicketItemFactory
 )
+from ticketing.models import BrownPaperEvents
 
 
 class TestGetTickets(TestCase):
     '''Tests for edit_event view'''
 
-    # Fixture to create some rooms, location items, and resource items
+    def setUp(self):
+        BrownPaperEvents.objects.all().delete()
 
     def test_get_tickets_for_volunteer_opp(self):
         '''should get no tickets, volunteer opportunities are free
@@ -25,25 +27,25 @@ class TestGetTickets(TestCase):
         event = GenericEventFactory()
         tickets = event.get_tickets()
 
-        self.assertEqual(tickets, {})
+        self.assertEqual(tickets, [])
 
     def test_get_tickets_for_master_class(self):
         '''get the one ticket that is active for the Master Class
         '''
         event = GenericEventFactory(
             type='Master')
-        bpt_event = BrownPaperEventsFactory(conference=event.e_conference)
+        bpt_event = BrownPaperEventsFactory(conference=event.e_conference,
+                                            title="Master Class 2017")
         bpt_event.linked_events.add(event)
         bpt_event.save()
         TicketItemFactory(bpt_event=bpt_event,
                           live=True,
-                          has_coupon=False,
-                          title="Master Class 2017")
+                          has_coupon=False)
         tickets = event.get_tickets()
 
         self.assertEqual(len(tickets), 1)
         self.assertEqual(
-            tickets[bpt_event.bpt_event_id].title,
+            tickets[0].title,
             "Master Class 2017")
 
     def test_get_tickets_for_special_event(self):
@@ -53,17 +55,17 @@ class TestGetTickets(TestCase):
             type='Special')
         bpt_event = BrownPaperEventsFactory(
             conference=event.e_conference,
-            include_most=True)
+            include_most=True,
+            title="The Whole Shebang 2016")
         TicketItemFactory(bpt_event=bpt_event,
                           live=True,
-                          has_coupon=False,
-                          title="The Whole Shebang 2016")
+                          has_coupon=False)
 
         tickets = event.get_tickets()
 
         self.assertEqual(len(tickets), 1)
         self.assertEqual(
-            tickets[bpt_event.bpt_event_id].title,
+            tickets[0].title,
             "The Whole Shebang 2016")
 
     def test_get_tickets_for_class(self):
@@ -72,29 +74,29 @@ class TestGetTickets(TestCase):
         event = ClassFactory()
         ws_bpt_event = BrownPaperEventsFactory(
             conference=event.e_conference,
-            include_most=True)
+            include_most=True,
+            title="The Whole Shebang 2016")
         sch_bpt_event = BrownPaperEventsFactory(
             conference=event.e_conference,
-            include_conference=True)
+            include_conference=True,
+            title="The Scholar 2016")
         whole_shebang = TicketItemFactory(
             bpt_event=ws_bpt_event,
             live=True,
-            has_coupon=False,
-            title="The Whole Shebang 2016")
+            has_coupon=False)
         scholar = TicketItemFactory(
             bpt_event=sch_bpt_event,
             live=True,
-            has_coupon=False,
-            title="The Scholar 2016")
+            has_coupon=False)
         tickets = event.get_tickets()
 
         self.assertEqual(len(tickets), 2)
         self.assertEqual(
-            tickets[ws_bpt_event.bpt_event_id],
-            whole_shebang)
+            tickets[0],
+            ws_bpt_event)
         self.assertEqual(
-            tickets[sch_bpt_event.bpt_event_id],
-            scholar)
+            tickets[1],
+            sch_bpt_event)
 
     def test_get_tickets_for_show(self):
         '''just gets 1 ticket for Whole Shebang
@@ -102,16 +104,16 @@ class TestGetTickets(TestCase):
         event = ShowFactory()
         bpt_event = BrownPaperEventsFactory(
             conference=event.e_conference,
-            include_most=True)
+            include_most=True,
+            title="The Whole Shebang 2016")
         TicketItemFactory(bpt_event=bpt_event,
                           live=True,
-                          has_coupon=False,
-                          title="The Whole Shebang 2016")
+                          has_coupon=False)
         tickets = event.get_tickets()
 
         self.assertEqual(len(tickets), 1)
         self.assertEqual(
-            tickets[bpt_event.bpt_event_id].title,
+            tickets[0].title,
             "The Whole Shebang 2016")
 
     def test_get_tickets_for_class_three_ways(self):
@@ -122,19 +124,18 @@ class TestGetTickets(TestCase):
         bpt_event = BrownPaperEventsFactory(
             conference=event.e_conference,
             include_most=True,
-            include_conference=True)
+            include_conference=True,
+            title="The Whole Shebang 2016")
         bpt_event.linked_events.add(event)
         bpt_event.save()
         TicketItemFactory(bpt_event=bpt_event,
                           live=True,
-                          has_coupon=False,
-                          title="The Whole Shebang 2016")
+                          has_coupon=False)
 
         tickets = event.get_tickets()
-
         self.assertEqual(len(tickets), 1)
         self.assertEqual(
-            tickets[bpt_event.bpt_event_id].title,
+            tickets[0].title,
             "The Whole Shebang 2016")
 
     def test_get_tickets_nothing_active(self):

--- a/expo/ticketing/functions.py
+++ b/expo/ticketing/functions.py
@@ -1,37 +1,30 @@
 from itertools import chain
 
 
-def get_unique_tickets(general_events):
-    unique_tickets = {}
-    for ticket_item in general_events:
-        if ticket_item.active and (
-                ticket_item.bpt_event.bpt_event_id not in unique_tickets or
-                ticket_item.cost > unique_tickets[
-                    ticket_item.bpt_event.bpt_event_id].cost):
-            unique_tickets[ticket_item.bpt_event.bpt_event_id] = ticket_item
-
-    return unique_tickets
-
-
 def get_tickets(linked_event, most=False, conference=False):
-    from ticketing.models import TicketItem
+    from ticketing.models import BrownPaperEvents
 
     general_events = []
 
     if most:
-        general_events = TicketItem.objects.filter(
-            bpt_event__include_most=True,
-            bpt_event__conference=linked_event.e_conference)
+        general_events = BrownPaperEvents.objects.filter(
+            include_most=True,
+            conference=linked_event.e_conference)
     if conference:
         general_events = list(chain(
             general_events,
-            TicketItem.objects.filter(
-                bpt_event__include_conference=True,
-                bpt_event__conference=linked_event.e_conference)))
+            BrownPaperEvents.objects.filter(
+                include_conference=True,
+                conference=linked_event.e_conference)))
 
     general_events = list(chain(
         general_events,
-        TicketItem.objects.filter(
-            bpt_event__linked_events=linked_event)))
+        BrownPaperEvents.objects.filter(
+            linked_events=linked_event)))
 
-    return get_unique_tickets(general_events)
+    ticket_events = []
+
+    for event in general_events:
+        if event.live_ticket_count > 0 and event not in ticket_events:
+            ticket_events += [event]
+    return ticket_events

--- a/expo/ticketing/models.py
+++ b/expo/ticketing/models.py
@@ -68,6 +68,13 @@ class BrownPaperEvents(models.Model):
             has_coupon=False).count() > 0
 
     @property
+    def live_ticket_count(self):
+        return TicketItem.objects.filter(
+            bpt_event=self,
+            live=True,
+            has_coupon=False).count()
+
+    @property
     def min_price(self):
         return TicketItem.objects.filter(
             bpt_event=self,


### PR DESCRIPTION
#1080 

fixed the view on event details in light of the new BPT title that should be the displayed title.