### PR TITLE
GBE-1126:  Make new review process reflected on landing page

### DIFF
--- a/expo/gbe/models/profile.py
+++ b/expo/gbe/models/profile.py
@@ -75,7 +75,7 @@ class Profile(WorkerItem):
         if 'Act Reviewers' in self.privilege_groups:
             from gbe.models import Act
             reviews += Act().bids_to_review.exclude(
-                bidevaluation__evaluator=self)
+                flexibleevaluation__evaluator=self)
         if 'Class Reviewers' in self.privilege_groups:
             from gbe.models import Class
             reviews += Class().bids_to_review.exclude(

--- a/expo/tests/gbe/test_landing_page.py
+++ b/expo/tests/gbe/test_landing_page.py
@@ -10,6 +10,7 @@ from tests.factories.gbe_factories import(
     ClassFactory,
     ConferenceFactory,
     CostumeFactory,
+    FlexibleEvaluationFactory,
     GenericEventFactory,
     PersonaFactory,
     ProfileFactory,
@@ -230,6 +231,18 @@ class TestIndex(TestCase):
         url = reverse('home', urlconf='gbe.urls')
         response = self.client.get(url)
         nt.assert_true(act.b_title in response.content)
+
+    def test_act_was_reviewed(self):
+        staff_profile = ProfileFactory(user_object__is_staff=True)
+        grant_privilege(staff_profile, "Act Reviewers")
+        login_as(staff_profile, self)
+        reviewed_act = ActFactory(submitted=True,
+                         b_conference=self.current_conf)
+        FlexibleEvaluationFactory(bid=reviewed_act,
+                                  evaluator=staff_profile)
+        url = reverse('home', urlconf='gbe.urls')
+        response = self.client.get(url)
+        self.assertNotContains(response, reviewed_act.b_title)
 
     def test_classes_to_review(self):
         staff_profile = ProfileFactory(user_object__is_staff=True)


### PR DESCRIPTION
On the landing page, the way bids were considered “reviewed” was if they had a bid eval.  I think it was actually broken for the last specialized act review way, too… but now it’s updated for flexible evals.

Wrote a test, since we didn’t have one.