### PR TITLE
GBE 1140: make draft a bid state

### DIFF
--- a/expo/gbe/email/forms/select_bidder_form.py
+++ b/expo/gbe/email/forms/select_bidder_form.py
@@ -5,6 +5,7 @@ from django.forms import (
     HiddenInput,
     ModelChoiceField,
     MultipleChoiceField,
+    MultipleHiddenInput,
 )
 from django.forms.widgets import CheckboxSelectMultiple
 from gbetext import acceptance_states
@@ -32,6 +33,11 @@ class SelectBidderForm(Form):
 class SecretBidderInfoForm(SelectBidderForm):
     conference = ModelChoiceField(
         queryset=Conference.objects.all().order_by('conference_name'),
-        widget=HiddenInput())
-    bid_type = ChoiceField(widget=HiddenInput())
-    state = MultipleChoiceField(widget=HiddenInput())
+        widget=HiddenInput(),
+        required=False)
+    bid_type = ChoiceField(widget=HiddenInput(),
+                           required=False)
+    state = MultipleChoiceField(
+        choices=((('Draft', 'Draft'),) + acceptance_states),
+        widget=MultipleHiddenInput(),
+        required=True)

--- a/expo/gbe/email/forms/select_bidder_form.py
+++ b/expo/gbe/email/forms/select_bidder_form.py
@@ -4,7 +4,9 @@ from django.forms import (
     Form,
     HiddenInput,
     ModelChoiceField,
+    MultipleChoiceField,
 )
+from django.forms.widgets import CheckboxSelectMultiple
 from gbetext import acceptance_states
 from gbe_forms_text import (
     event_help_texts,
@@ -21,8 +23,10 @@ class SelectBidderForm(Form):
         empty_label=("All"),
         required=False)
     bid_type = ChoiceField(required=False)
-    state = ChoiceField(choices=((('', 'All'),) + acceptance_states),
-                        required=False)
+    state = MultipleChoiceField(
+        choices=((('Draft', 'Draft'),) + acceptance_states),
+        widget=CheckboxSelectMultiple(attrs={'checked' : 'checked'}),
+        required=True)
 
 
 class SecretBidderInfoForm(SelectBidderForm):
@@ -30,4 +34,4 @@ class SecretBidderInfoForm(SelectBidderForm):
         queryset=Conference.objects.all().order_by('conference_name'),
         widget=HiddenInput())
     bid_type = ChoiceField(widget=HiddenInput())
-    state = ChoiceField(widget=HiddenInput())
+    state = MultipleChoiceField(widget=HiddenInput())

--- a/expo/gbe/email/forms/select_bidder_form.py
+++ b/expo/gbe/email/forms/select_bidder_form.py
@@ -25,7 +25,7 @@ class SelectBidderForm(Form):
     bid_type = ChoiceField(required=False)
     state = MultipleChoiceField(
         choices=((('Draft', 'Draft'),) + acceptance_states),
-        widget=CheckboxSelectMultiple(attrs={'checked' : 'checked'}),
+        widget=CheckboxSelectMultiple(),
         required=True)
 
 

--- a/expo/gbe/email/views/mail_to_bidders_view.py
+++ b/expo/gbe/email/views/mail_to_bidders_view.py
@@ -53,7 +53,8 @@ class MailToBiddersView(View):
                 request.POST,
                 prefix="email-select")
         else:
-            self.select_form = SelectBidderForm(prefix="email-select")
+            self.select_form = SelectBidderForm(prefix="email-select",
+                                                initial={'state': [0, 1, 2, 3, 4, 5, 6]})
         for priv in priv_list:
             self.bid_type_choices += [(priv.title(), priv.title())]
 
@@ -81,9 +82,9 @@ class MailToBiddersView(View):
             draft_query = query & Q(submitted=False)
 
         if len(accept_states) > 0:
-            query = query & Q(accepted__in=accept_states)
+            query = query & Q(accepted__in=accept_states) & Q(submitted=True)
         elif draft:
-            query = query & Q(submitted=False)
+            query = draft_query
             draft=False
 
         for bid_type in bid_types:

--- a/expo/gbe/email/views/mail_to_bidders_view.py
+++ b/expo/gbe/email/views/mail_to_bidders_view.py
@@ -119,11 +119,8 @@ class MailToBiddersView(View):
             'sender': self.user.user_object.email})
         if not request.user.is_superuser:
             email_form.fields['sender'].widget = HiddenInput()
-        recipient_info = SecretBidderInfoForm(initial={
-            'conference': self.select_form.cleaned_data['conference'],
-            'bid_type': self.select_form.cleaned_data['bid_type'],
-            'state': self.select_form.cleaned_data['state'],
-            }, prefix="email-select")
+        recipient_info = SecretBidderInfoForm(request.POST,
+                                              prefix="email-select")
         recipient_info.fields['bid_type'].choices = self.bid_type_choices
 
         return render(

--- a/expo/gbe/email/views/mail_to_bidders_view.py
+++ b/expo/gbe/email/views/mail_to_bidders_view.py
@@ -53,8 +53,9 @@ class MailToBiddersView(View):
                 request.POST,
                 prefix="email-select")
         else:
-            self.select_form = SelectBidderForm(prefix="email-select",
-                                                initial={'state': [0, 1, 2, 3, 4, 5, 6]})
+            self.select_form = SelectBidderForm(
+                prefix="email-select",
+                initial={'state': [0, 1, 2, 3, 4, 5, 6]})
         for priv in priv_list:
             self.bid_type_choices += [(priv.title(), priv.title())]
 
@@ -85,7 +86,7 @@ class MailToBiddersView(View):
             query = query & Q(accepted__in=accept_states) & Q(submitted=True)
         elif draft:
             query = draft_query
-            draft=False
+            draft = False
 
         for bid_type in bid_types:
             for bid in eval(bid_type).objects.filter(query):

--- a/expo/gbe/templates/gbe/email/mail_to_bidders.tmpl
+++ b/expo/gbe/templates/gbe/email/mail_to_bidders.tmpl
@@ -60,8 +60,7 @@
       <div class="form-group col-md-9 col-xs-12">
       {% for checkbox in selection_form.state %}
         <label class="checkbox-inline" id="{{ checkbox.id_for_label }}">
-          {{ checkbox.tag }}
-          {{ field.label_tag }}
+          {{ checkbox.tag }}{{ field.label_tag }}
             {{ checkbox.choice_label }}
         </label>{% endfor %}
         {% if selection_form.state.errors %}

--- a/expo/gbe/templates/gbe/email/mail_to_bidders.tmpl
+++ b/expo/gbe/templates/gbe/email/mail_to_bidders.tmpl
@@ -21,44 +21,56 @@
     <p style= "color:red"> There is an error on the form.</p>
   {% endif %}
   {{ selection_form.non_field_errors }}</font>
-  <form action="" method="post" enctype="multipart/form-data">
+  <form class="form-inline" action="" method="post" enctype="multipart/form-data">
     {% csrf_token %}
-    <div class="email-select container">
-    <div class="row">
-    {# Include the visible fields #}
-    {% for field in selection_form.visible_fields %}
-      {% if forloop.first %}
-      <div class="col-md-5 col-sm-6 col-xs-12">
-      {% else %}
-      <div class="col-md-3 col-sm-2 col-xs-12">
-      {% endif %}
-	<label for="field.name" class="control-label">	      
-          {% if field.errors %}
-            <font color="red">!</font>&nbsp;&nbsp;
-	  {% elif field.css_classes == 'required' or field.name in submit_fields %}
-            <font color="red">*</font>
-          {% endif %} 
-          {% if field.errors %}
-            <font color="red">
-          {% endif %}
-          {% if field.name in draft_fields %}
-	      <b>{{ field.label_tag }}</b>
-          {% else %}
-            {{ field.label_tag }}
-	  {% endif %}
-          {% if field.errors %}
-            </font>
-          {% endif %} 
- 	</label>
-        {{ field }}
-      {% if field.errors %}
- 	<label for="field.name"><font color="red">{{ field.errors }}</font></label>
-      {% endif %}
+    <div class="form-row email-select">
+      <div class="form-group col-md-6">
+        {% if selection_form.conference.errors %}
+          <font color="red">!&nbsp;&nbsp;
+        {% endif %} 
+        <label class="form-check-label" id="{{ selection_form.conference.name }}">
+          {{ selection_form.conference.label }}:&nbsp;&nbsp;{{ selection_form.conference }}
+        {% if selection_form.conference.errors %}
+          {{ selection_form.conference.errors }}</font>
+        {% endif %}
+        </label>
       </div>
-    {% endfor %}
-      <div class="col-md-1 col-sm-2 col-xs-12 email-submit">
+      <div class="form-group col-md-6">
+        {% if selection_form.bid_type.errors %}
+          <font color="red">!&nbsp;&nbsp;
+        {% endif %} 
+         <label class="form-check-label" id="{{ selection_form.bid_type.name }}">
+          {{ selection_form.bid_type.label }}:&nbsp;&nbsp;{{ selection_form.bid_type }}
+        {% if selection_form.bid_type.errors %}
+          {{ selection_form.bid_type.errors }}</font>
+        {% endif %}
+         </label>
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="form-group col-md-2 col-xs-12">
+        <label class="form-check-label" id="{{ selection_form.state.name }}">
+          {% if selection_form.state.errors %}
+            <font color="red">!&nbsp;&nbsp;
+          {% endif %}
+          {{ selection_form.state.label }}:&nbsp;&nbsp;</label></div>
+          {% if selection_form.state.errors %}
+            </font>
+          {% endif %}
+      <div class="form-group col-md-9 col-xs-12">
+      {% for checkbox in selection_form.state %}
+        <label class="checkbox-inline" id="{{ checkbox.id_for_label }}">
+          {{ checkbox.tag }}
+          {{ field.label_tag }}
+            {{ checkbox.choice_label }}
+        </label>{% endfor %}
+        {% if selection_form.state.errors %}
+          {{ selection_form.state.errors }}</font>
+        {% endif %}
+      </div>
+      <div class="form-group col-md-1 col-xs-12">
          <input type="submit" class="email-submit" name="filter" value="Filter">
-      </div></div></div>
+      </div></div>
     </form>
   </div>
 </div>

--- a/expo/tests/contexts/class_context.py
+++ b/expo/tests/contexts/class_context.py
@@ -42,7 +42,8 @@ class ClassContext:
         self.bid = bid or ClassFactory(b_conference=self.conference,
                                        e_conference=self.conference,
                                        accepted=3,
-                                       teacher=self.teacher)
+                                       teacher=self.teacher,
+                                       submitted=True)
         self.room = room or RoomFactory()
         self.sched_event = None
         self.sched_event = self.schedule_instance(room=self.room,

--- a/expo/tests/gbe/email/test_mail_to_bidders.py
+++ b/expo/tests/gbe/email/test_mail_to_bidders.py
@@ -125,6 +125,7 @@ class TestMailToBidder(TestCase):
         login_as(self.privileged_profile, self)
         data = {
             'email-select-conference': self.context.conference.pk,
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'filter': True,
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -140,6 +141,7 @@ class TestMailToBidder(TestCase):
         login_as(self.privileged_profile, self)
         data = {
             'email-select-bid_type': "Class",
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'filter': True,
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -155,6 +157,7 @@ class TestMailToBidder(TestCase):
         login_as(self.privileged_profile, self)
         data = {
             'email-select-state': 3,
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'filter': True,
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -170,6 +173,7 @@ class TestMailToBidder(TestCase):
         self.reduced_login()
         data = {
             'email-select-bid_type': "Class",
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'filter': True,
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -182,6 +186,7 @@ class TestMailToBidder(TestCase):
         second_bid = ActFactory()
         self.reduced_login()
         data = {
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'filter': True,
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -195,6 +200,7 @@ class TestMailToBidder(TestCase):
     def test_pick_no_bidders(self):
         reduced_profile = self.reduced_login()
         data = {
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'filter': True,
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -204,6 +210,7 @@ class TestMailToBidder(TestCase):
     def test_pick_admin_has_sender(self):
         login_as(self.privileged_profile, self)
         data = {
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'filter': True,
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -217,6 +224,7 @@ class TestMailToBidder(TestCase):
         ActFactory()
         reduced_profile = self.reduced_login()
         data = {
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'filter': True,
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -227,17 +235,15 @@ class TestMailToBidder(TestCase):
 
     def test_send_email_success_status(self):
         login_as(self.privileged_profile, self)
-        to_list = {}
-        to_list[self.context.teacher.contact.user_object.email] = \
-            self.context.teacher.contact.display_name
         data = {
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
-            'email-select-to_list': str(to_list),
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
+        print response.content
         assert_alert_exists(
             response, 'success', 'Success', "%s%s (%s), " % (
                 send_email_success_msg,
@@ -254,6 +260,7 @@ class TestMailToBidder(TestCase):
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
             'email-select-to_list': str(to_list),
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -271,6 +278,7 @@ class TestMailToBidder(TestCase):
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -289,6 +297,7 @@ class TestMailToBidder(TestCase):
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
             'email-select-bid_type': "Class",
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -305,6 +314,7 @@ class TestMailToBidder(TestCase):
         data = {
             'sender': "sender@admintest.com",
             'html_message': "<p>Test Message</p>",
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -318,6 +328,7 @@ class TestMailToBidder(TestCase):
         data = {
             'sender': "sender@admintest.com",
             'html_message': "<p>Test Message</p>",
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -336,6 +347,7 @@ class TestMailToBidder(TestCase):
             'sender': "sender@admintest.com",
             'html_message': "<p>Test Message</p>",
             'email-select-conference': self.context.conference.pk,
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -354,6 +366,7 @@ class TestMailToBidder(TestCase):
             'sender': "sender@admintest.com",
             'html_message': "<p>Test Message</p>",
             'email-select-bid_type': "Class",
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -370,6 +383,7 @@ class TestMailToBidder(TestCase):
             'sender': "sender@admintest.com",
             'html_message': "<p>Test Message</p>",
             'email-select-state': 3,
+            'email-select-state': [0, 1, 2, 3, 4, 5],
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
@@ -383,9 +397,8 @@ class TestMailToBidder(TestCase):
         second_class = ClassFactory(accepted=2)
         login_as(self.privileged_profile, self)
         data = {
-            'email-select-state': 3,
+            'email-select-state': [0, 1, 2, 3, 4, 5],
         }
         response = self.client.post(self.url, data=data, follow=True)
-        print response.content
         assert_alert_exists(
             response, 'danger', 'Error', unknown_request)

--- a/expo/tests/gbe/email/test_mail_to_bidders.py
+++ b/expo/tests/gbe/email/test_mail_to_bidders.py
@@ -171,6 +171,42 @@ class TestMailToBidder(TestCase):
             response,
             second_class.teacher.contact.user_object.email)
 
+    def test_pick_class_draft(self):
+        second_bid = ClassFactory()
+        login_as(self.privileged_profile, self)
+        data = {
+            'email-select-bid_type': "Class",
+            'email-select-state': ["Draft"],
+            'filter': True,
+        }
+        response = self.client.post(self.url, data=data, follow=True)
+        self.assertNotContains(
+            response,
+            self.context.teacher.contact.user_object.email)
+        self.assertContains(
+            response,
+            second_bid.teacher.contact.user_object.email)
+
+    def test_pick_class_draft_and_accept(self):
+        second_bid = ClassFactory()
+        third_bid = ClassFactory(submitted=True)
+        login_as(self.privileged_profile, self)
+        data = {
+            'email-select-bid_type': "Class",
+            'email-select-state': ["Draft", 3],
+            'filter': True,
+        }
+        response = self.client.post(self.url, data=data, follow=True)
+        self.assertContains(
+            response,
+            self.context.teacher.contact.user_object.email)
+        self.assertContains(
+            response,
+            second_bid.teacher.contact.user_object.email)
+        self.assertNotContains(
+            response,
+            third_bid.teacher.contact.user_object.email)
+
     def test_pick_forbidden_bid_type_reduced_priv(self):
         second_bid = ActFactory()
         self.reduced_login()


### PR DESCRIPTION
Added Drafts to the bid states
Turned bid states into checkboxes so that “Drafts” are all not-submitted bids, and then the other states apply to only submitted bids and the value of the acceptance field.

That meant a lot of mucking into the filter to make the checkbox display look nice.