### PR TITLE
GBE-1177: Assign volunteers missing CSS & JS for DataTables

### DIFF
--- a/expo/gbe/templates/gbe/assign_volunteer.tmpl
+++ b/expo/gbe/templates/gbe/assign_volunteer.tmpl
@@ -5,6 +5,11 @@
   Assign Volunteer Slots
 {% endblock %}
 
+{% block head %}
+    <script type="text/javascript" charset="utf8" src="//cdn.datatables.net/1.10.10/js/jquery.dataTables.js"></script>
+    <link rel="stylesheet" type="text/css" href="//cdn.datatables.net/1.10.10/css/jquery.dataTables.css">
+{% endblock %}
+
 {% block content %}
 <div class="special_functions">
   <a href="{% url 'gbe:volunteer_review_list' %}">Review All Volunteers</a> <br/>


### PR DESCRIPTION
Fixes #1177 

The fix was easy and well known - include the datatable CSS and JS files.

This also fixed the issue with the special menu.  I surmise that the epic fail of the JS at the end of this page, that controls the data tables, somehow took down the JS for the special menu, too.