### PR TITLE
GBE 1176:  Fix & improve view troupe info

### DIFF
--- a/expo/tests/gbe/test_edit_troupe.py
+++ b/expo/tests/gbe/test_edit_troupe.py
@@ -112,6 +112,20 @@ class TestEditTroupe(TestCase):
                       args=[troupe.pk],
                       urlconf='gbe.urls')
         login_as(persona.performer_profile.profile, self)
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.status_code, 404)
+
+    def test_edit_as_member(self):
+        '''edit_troupe view, edit flow success
+        '''
+        persona = PersonaFactory()
+        troupe = TroupeFactory()
+        troupe.membership.add(persona)
+        troupe.save()
+        url = reverse(self.view_name,
+                      args=[troupe.pk],
+                      urlconf='gbe.urls')
+        login_as(persona.performer_profile.profile, self)
         response = self.client.get(url)
         self.assertRedirects(
             response,

--- a/expo/tests/gbe/test_view_troupe.py
+++ b/expo/tests/gbe/test_view_troupe.py
@@ -99,3 +99,18 @@ class TestViewTroupe(TestCase):
         self.assertContains(response, troupe.name)
         self.assertContains(response, troupe.contact.user_object.email)
         self.assertContains(response, member.name)
+
+    def test_view_troupe_as_random_person(self):
+        '''view_troupe view, success
+        '''
+        persona = PersonaFactory()
+        random = ProfileFactory()
+        contact = persona.performer_profile
+        troupe = TroupeFactory(contact=contact)
+        url = reverse('troupe_view',
+                      args=[troupe.resourceitem_id],
+                      urlconf='gbe.urls')
+        login_as(random.user_object, self)
+
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)


### PR DESCRIPTION
the bug was that the view doesn’t consider the case when the user is NOT the troupe contact.  So the “contact info” part of the display is actually seeded with the current user’s info.

In looking at this, it was clear that this is a REALLY old and fairly incomplete - the most obvious problem was that there is NO access control on this, other than that the user is logged in.  That sucks, since there is personal contact info here, and any random user could game the system and harvest troupe contact details.  Ick. 

Fixed that, couldn’t leave it alone.

Also, the testing in this area was the most trivial tests imaginable, so I added both better checks AND more tests for my new cases and the bug fix.