### PR TITLE
GBE-1203:  Throw HTTP 404 when format is bad

### DIFF
--- a/expo/gbe/scheduling/views/show_calendar_view.py
+++ b/expo/gbe/scheduling/views/show_calendar_view.py
@@ -57,10 +57,13 @@ class ShowCalendarView(View):
                 raise Http404
 
         if "day" in self.request.GET:
-            self.this_day = get_object_or_404(
-                ConferenceDay,
-                day=datetime.strptime(self.request.GET.get('day', None),
-                                      URL_DATE))
+            try:
+                self.this_day = get_object_or_404(
+                    ConferenceDay,
+                    day=datetime.strptime(self.request.GET.get('day', None),
+                                          URL_DATE))
+            except ValueError:
+                raise Http404
             self.conference = self.this_day.conference
 
         elif "conference" in self.request.GET:

--- a/expo/tests/gbe/scheduling/test_calendar_view.py
+++ b/expo/tests/gbe/scheduling/test_calendar_view.py
@@ -158,6 +158,17 @@ class TestCalendarView(TestCase):
         response = self.client.get(url, data=data)
         self.assertEqual(response.status_code, 404)
 
+    def test_invalid_day(self):
+        '''
+        There is a day, but that's not the day we're asking for.
+        '''
+        url = reverse('calendar',
+                      urlconf='gbe.scheduling.urls',
+                      args=['Conference'])
+        data = {'day': "DEADBEEF"}
+        response = self.client.get(url, data=data)
+        self.assertEqual(response.status_code, 404)
+
     def test_bad_cal_type(self):
         url = reverse('calendar',
                       urlconf='gbe.scheduling.urls',


### PR DESCRIPTION
Don’t help URL hackers game the system… throw the same error regardless of the problem - 404, not found.

