### PR TITLE
GBE-1209 & 1206: Fix problems in templates

### DIFF
--- a/expo/gbe/email/functions.py
+++ b/expo/gbe/email/functions.py
@@ -28,12 +28,15 @@ def mail_send_gbe(to_list,
         for admin in settings.ADMINS:
             to_list += [admin[1]]
 
-    mail.send(to_list,
-              from_address,
-              template=template,
-              context=context,
-              priority=priority,
-              )
+    try:
+        mail.send(to_list,
+                  from_address,
+                  template=template,
+                  context=context,
+                  priority=priority,
+                  )
+    except:
+        return "EMAIL_SEND_ERROR"
 
 
 def send_user_contact_email(name, from_address, message):
@@ -131,12 +134,11 @@ def send_bid_state_change_mail(
         name,
         "default_bid_status_change",
         action)
-    mail_send_gbe(
+    return mail_send_gbe(
         email,
         template.sender.from_email,
         template=name,
-        context=context,
-    )
+        context=context)
 
 
 def send_schedule_update_mail(participant_type, profile):
@@ -146,7 +148,7 @@ def send_schedule_update_mail(participant_type, profile):
         "volunteer_schedule_update",
         "A change has been made to your %s Schedule!" % (
                 participant_type))
-    mail_send_gbe(
+    return mail_send_gbe(
         profile.contact_email,
         template.sender.from_email,
         template=name,

--- a/expo/gbe/email/functions.py
+++ b/expo/gbe/email/functions.py
@@ -152,7 +152,15 @@ def send_schedule_update_mail(participant_type, profile):
         template=name,
         context={
             'site': Site.objects.get_current().domain,
-            'profile': profile},
+            'profile': profile,
+            'landing_page_url': "http://%s%s" % (
+                Site.objects.get_current().domain,
+                reverse('home',
+                        urlconf='gbe.urls')),
+            'landing_page_link': "<a href='http://%s%s'>Personal Page</a>" % (
+                Site.objects.get_current().domain,
+                reverse('home',
+                        urlconf='gbe.urls'))},
     )
 
 

--- a/expo/gbe/scheduling/views/allocate_worker_view.py
+++ b/expo/gbe/scheduling/views/allocate_worker_view.py
@@ -115,7 +115,8 @@ class AllocateWorkerView(MakeOccurrenceView):
                     occurrence_id,
                     person
                 )
-                email_status = send_schedule_update_mail("Volunteer", data['worker'])
+                email_status = send_schedule_update_mail("Volunteer",
+                                                         data['worker'])
             if email_status:
                 user_message = UserMessage.objects.get_or_create(
                     view=self.__class__.__name__,

--- a/expo/gbe/scheduling/views/allocate_worker_view.py
+++ b/expo/gbe/scheduling/views/allocate_worker_view.py
@@ -16,6 +16,9 @@ from gbe.scheduling.forms import WorkerAllocationForm
 from gbe.scheduling.views.functions import get_single_role
 from gbe.email.functions import send_schedule_update_mail
 from gbe.scheduling.views.functions import show_scheduling_booking_status
+from gbetext import volunteer_allocate_email_fail_msg
+from django.contrib import messages
+from gbe.models import UserMessage
 
 
 class AllocateWorkerView(MakeOccurrenceView):
@@ -58,6 +61,7 @@ class AllocateWorkerView(MakeOccurrenceView):
         form = WorkerAllocationForm(request.POST)
         response = None
         occurrence_id = None
+        email_status = None
         if "occurrence_id" in kwargs:
             occurrence_id = int(kwargs['occurrence_id'])
         if not form.is_valid():
@@ -93,7 +97,7 @@ class AllocateWorkerView(MakeOccurrenceView):
                     occurrence_id,
                     booking_id=int(request.POST['alloc_id']))
                 if response.booking_id:
-                    send_schedule_update_mail(
+                    email_status = send_schedule_update_mail(
                         "Volunteer", data['worker'].workeritem.as_subtype)
             elif data.get('worker', None):
                 if data['role'] == "Volunteer":
@@ -111,7 +115,17 @@ class AllocateWorkerView(MakeOccurrenceView):
                     occurrence_id,
                     person
                 )
-                send_schedule_update_mail("Volunteer", data['worker'])
+                email_status = send_schedule_update_mail("Volunteer", data['worker'])
+            if email_status:
+                user_message = UserMessage.objects.get_or_create(
+                    view=self.__class__.__name__,
+                    code="EMAIL_FAILURE",
+                    defaults={
+                        'summary': "Email Failed",
+                        'description': volunteer_allocate_email_fail_msg})
+                messages.error(
+                    request,
+                    user_message[0].description)
             self.success_url = reverse('edit_event_schedule',
                                        urlconf='gbe.scheduling.urls',
                                        args=[self.event_type,

--- a/expo/gbe/scheduling/views/functions.py
+++ b/expo/gbe/scheduling/views/functions.py
@@ -130,7 +130,9 @@ def show_scheduling_occurrence_status(request, occurrence_response, view):
 # These three messages are not mutually exclusive.  Order of operation is most
 #   severe (error) to least severe (success)
 #
-def show_scheduling_booking_status(request, booking_response, view):
+def show_scheduling_booking_status(request,
+                                   booking_response,
+                                   view):
     show_general_status(request, booking_response, view)
 
     if booking_response.booking_id:

--- a/expo/gbe/templates/gbe/email/volunteer_schedule_update.tmpl
+++ b/expo/gbe/templates/gbe/email/volunteer_schedule_update.tmpl
@@ -5,7 +5,7 @@ Dear {{ profile.display_name }},
 Thank you for participating in The Great Burlesque Exposition! An update has
 been made to your volunteer schedule. Your current volunteer schedule is listed
 below; you can also check your schedule at anytime by logging in to the site and
-looking at your personal page.
+looking at your personal page - {{ landing_page_url }}.
 
 {% volunteer_schedule_plaintext profile %}
 

--- a/expo/gbe/templates/gbe/email/volunteer_schedule_update_html.tmpl
+++ b/expo/gbe/templates/gbe/email/volunteer_schedule_update_html.tmpl
@@ -5,7 +5,7 @@
 <p>Thank you for participating in The Great Burlesque Exposition! An update has
 been made to your volunteer schedule. Your current volunteer schedule is listed
 below; you can also check your schedule at anytime by logging in to the site and
-looking at your <a href="{{site}}{% url 'gbe:home' %}">personal page.</a></p>
+looking at your {{ landing_page_link }}</p>
 
 {% volunteer_schedule profile %}
 

--- a/expo/gbe/views/act_changestate_view.py
+++ b/expo/gbe/views/act_changestate_view.py
@@ -93,13 +93,14 @@ class ActChangeStateView(BidChangeStateView):
             # only send the show when act is accepted
             if request.POST['accepted'] == '3':
                 email_show = self.new_show
-            send_bid_state_change_mail(
+            email_status = send_bid_state_change_mail(
                 str(self.object_type.__name__).lower(),
                 self.bidder.contact_email,
                 self.bidder.get_badge_name(),
                 self.object,
                 int(request.POST['accepted']),
                 show=email_show)
+            self.check_email_status(request, email_status)
 
     def prep_bid(self, request, args, kwargs):
         super(ActChangeStateView, self).prep_bid(request, args, kwargs)

--- a/expo/gbe/views/bid_changestate_view.py
+++ b/expo/gbe/views/bid_changestate_view.py
@@ -55,7 +55,7 @@ class BidChangeStateView(View):
                 self.object,
                 int(request.POST['accepted']))
             self.check_email_status(request, email_status)
-    
+
     def check_email_status(self, request, email_status):
         if email_status:
             user_message = UserMessage.objects.get_or_create(

--- a/expo/gbe/views/bid_changestate_view.py
+++ b/expo/gbe/views/bid_changestate_view.py
@@ -1,6 +1,7 @@
 from django.views.generic import View
 from django.views.decorators.cache import never_cache
 from django.utils.decorators import method_decorator
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import (
     get_object_or_404,
@@ -9,10 +10,14 @@ from django.shortcuts import (
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from expo.gbe_logging import log_func
-from gbe.models import Biddable
+from gbe.models import (
+    Biddable,
+    UserMessage,
+)
 from gbe.forms import BidStateChangeForm
 from gbe.functions import validate_perms
 from gbe.email.functions import send_bid_state_change_mail
+from gbetext import bidder_email_fail_msg
 
 
 class BidChangeStateView(View):
@@ -43,12 +48,25 @@ class BidChangeStateView(View):
 
     def notify_bidder(self, request):
         if str(self.object.accepted) != request.POST['accepted']:
-            send_bid_state_change_mail(
+            email_status = send_bid_state_change_mail(
                 str(self.object_type.__name__).lower(),
                 self.bidder.contact_email,
                 self.bidder.get_badge_name(),
                 self.object,
                 int(request.POST['accepted']))
+            self.check_email_status(request, email_status)
+    
+    def check_email_status(self, request, email_status):
+        if email_status:
+            user_message = UserMessage.objects.get_or_create(
+                view=self.__class__.__name__,
+                code="EMAIL_FAILURE",
+                defaults={
+                    'summary': "Email Failed",
+                    'description': bidder_email_fail_msg})
+            messages.error(
+                request,
+                user_message[0].description)
 
     def groundwork(self, request, args, kwargs):
         self.prep_bid(request, args, kwargs)

--- a/expo/gbe/views/volunteer_changestate_view.py
+++ b/expo/gbe/views/volunteer_changestate_view.py
@@ -7,9 +7,6 @@ from gbe.views import BidChangeStateView
 from scheduler.models import Worker, Event
 from django.contrib import messages
 from gbe.email.functions import send_schedule_update_mail
-from gbetext import volunteer_allocate_email_fail_msg
-from django.contrib import messages
-from gbe.models import UserMessage
 
 
 class VolunteerChangeStateView(BidChangeStateView):
@@ -44,15 +41,7 @@ class VolunteerChangeStateView(BidChangeStateView):
                                      warning)
 
             email_status = send_schedule_update_mail('Volunteer', self.bidder)
-            if email_status:
-                user_message = UserMessage.objects.get_or_create(
-                    view=self.__class__.__name__,
-                    code="EMAIL_FAILURE",
-                    defaults={
-                        'summary': "Email Failed",
-                        'description': volunteer_allocate_email_fail_msg})
-                messages.error(
-                    request,
-                    user_message[0].description)
+            self.check_email_status(request, email_status)
+
         return super(VolunteerChangeStateView, self).bid_state_change(
             request)

--- a/expo/gbe/views/volunteer_changestate_view.py
+++ b/expo/gbe/views/volunteer_changestate_view.py
@@ -7,6 +7,9 @@ from gbe.views import BidChangeStateView
 from scheduler.models import Worker, Event
 from django.contrib import messages
 from gbe.email.functions import send_schedule_update_mail
+from gbetext import volunteer_allocate_email_fail_msg
+from django.contrib import messages
+from gbe.models import UserMessage
 
 
 class VolunteerChangeStateView(BidChangeStateView):
@@ -40,6 +43,16 @@ class VolunteerChangeStateView(BidChangeStateView):
                     messages.warning(request,
                                      warning)
 
-            send_schedule_update_mail('Volunteer', self.bidder)
+            email_status = send_schedule_update_mail('Volunteer', self.bidder)
+            if email_status:
+                user_message = UserMessage.objects.get_or_create(
+                    view=self.__class__.__name__,
+                    code="EMAIL_FAILURE",
+                    defaults={
+                        'summary': "Email Failed",
+                        'description': volunteer_allocate_email_fail_msg})
+                messages.error(
+                    request,
+                    user_message[0].description)
         return super(VolunteerChangeStateView, self).bid_state_change(
             request)

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -475,3 +475,7 @@ imply anything about ticket purchase.'''
 volunteer_allocate_email_fail_msg = '''The system was not able to send email \
 to the volunteer.  Check the email template, try again, or mail the volunteer \
 manually.  If the issue persists, please contact the web admin.'''
+bidder_email_fail_msg = '''The system was unable to send an email notifying \
+the bidder of the updates you have made.  Check the email template, try \
+again, or mail the bidder manually.  If the issue persists, please contact \
+the web admin.'''

--- a/expo/gbetext.py
+++ b/expo/gbetext.py
@@ -472,3 +472,6 @@ interested_report_explain_msg = '''This list includes all scheduled \
 classes and provides a count of how many logged in users have shown interest \
 in the class.  Interest does not reflect a firm commitment, nor does it \
 imply anything about ticket purchase.'''
+volunteer_allocate_email_fail_msg = '''The system was not able to send email \
+to the volunteer.  Check the email template, try again, or mail the volunteer \
+manually.  If the issue persists, please contact the web admin.'''

--- a/expo/tests/functions/gbe_functions.py
+++ b/expo/tests/functions/gbe_functions.py
@@ -167,6 +167,7 @@ def assert_email_template_used(
     msg = mail.outbox[0]
     assert msg.subject == expected_subject
     assert msg.from_email == email
+    return msg
 
 
 def assert_email_recipient(to_list):

--- a/expo/tests/gbe/scheduling/test_allocate_workers.py
+++ b/expo/tests/gbe/scheduling/test_allocate_workers.py
@@ -18,6 +18,7 @@ from tests.functions.gbe_functions import (
 )
 from django.shortcuts import get_object_or_404
 from gbe.models import Volunteer
+from django.contrib.sites.models import Site
 
 
 class TestAllocateWorkers(TestCase):
@@ -355,8 +356,11 @@ class TestAllocateWorkers(TestCase):
                               self.volunteer_opp.eventitem.eventitem_id,
                               self.volunteer_opp.pk]),
                 self.alloc.pk))
-        assert_email_template_used(
+        msg = assert_email_template_used(
             "A change has been made to your Volunteer Schedule!")
+        assert("http://%s%s" % (
+            Site.objects.get_current().domain,
+            reverse('home', urlconf='gbe.urls')) in msg.body)
 
     def test_post_form_valid_delete_allocation_w_bad_data(self):
         data = self.get_edit_data()

--- a/expo/tests/gbe/scheduling/test_allocate_workers.py
+++ b/expo/tests/gbe/scheduling/test_allocate_workers.py
@@ -4,6 +4,7 @@ from django.test import (
 )
 from django.core.urlresolvers import reverse
 from tests.factories.gbe_factories import (
+    EmailTemplateSenderFactory,
     ProfileFactory,
     VolunteerFactory,
     VolunteerInterestFactory,
@@ -19,6 +20,7 @@ from tests.functions.gbe_functions import (
 from django.shortcuts import get_object_or_404
 from gbe.models import Volunteer
 from django.contrib.sites.models import Site
+from gbetext import volunteer_allocate_email_fail_msg
 
 
 class TestAllocateWorkers(TestCase):
@@ -362,6 +364,29 @@ class TestAllocateWorkers(TestCase):
             Site.objects.get_current().domain,
             reverse('home', urlconf='gbe.urls')) in msg.body)
 
+    def test_post_form_valid_notification_template_fail(self):
+        EmailTemplateSenderFactory(
+            from_email="scheduleemail@notify.com",
+            template__name='volunteer schedule update',
+            template__subject="test template",
+            template__content="stuff {% url 'gbehome' %}  more stuff"
+        )
+        data = self.get_edit_data()
+        data['delete'] = 1
+        login_as(self.privileged_profile, self)
+        response = self.client.post(self.url, data=data, follow=True)
+        self.assertRedirects(
+            response,
+            "%s?changed_id=%d" % (
+                reverse('edit_event_schedule',
+                        urlconf='gbe.scheduling.urls',
+                        args=["GenericEvent",
+                              self.volunteer_opp.eventitem.eventitem_id,
+                              self.volunteer_opp.pk]),
+                self.alloc.pk))
+        self.assertContains(response,
+                            volunteer_allocate_email_fail_msg)
+
     def test_post_form_valid_delete_allocation_w_bad_data(self):
         data = self.get_edit_data()
         data['role'] = ''
@@ -408,6 +433,22 @@ class TestAllocateWorkers(TestCase):
         response = self.client.post(self.url, data=data, follow=True)
         assert_email_template_used(
             "A change has been made to your Volunteer Schedule!")
+
+    def test_post_form_edit_notification_template_fail(self):
+        EmailTemplateSenderFactory(
+            from_email="scheduleemail@notify.com",
+            template__name='volunteer schedule update',
+            template__subject="test template",
+            template__content="stuff {% url 'gbehome' %}  more stuff"
+        )
+        new_volunteer = ProfileFactory()
+        data = self.get_edit_data()
+        data['worker'] = new_volunteer.pk,
+        data['role'] = 'Producer',
+        login_as(self.privileged_profile, self)
+        response = self.client.post(self.url, data=data, follow=True)
+        self.assertContains(response,
+                            volunteer_allocate_email_fail_msg)
 
     def test_post_form_valid_make_new_allocation_w_confict(self):
         data = self.get_create_data()

--- a/expo/tests/gbe/test_act_changestate.py
+++ b/expo/tests/gbe/test_act_changestate.py
@@ -32,7 +32,10 @@ from scheduler.models import (
     ResourceAllocation,
 )
 from gbe.models import UserMessage
-from gbetext import no_casting_msg
+from gbetext import (
+    bidder_email_fail_msg,
+    no_casting_msg,
+)
 
 
 class TestActChangestate(TestCase):
@@ -159,6 +162,21 @@ class TestActChangestate(TestCase):
             "test template", "actemail@notify.com")
         assert_email_recipient([(
             self.context.performer.contact.contact_email)])
+
+    def test_act_accept_notification_template_fail(self):
+        EmailTemplateSenderFactory(
+            from_email="actemail@notify.com",
+            template__name='act accepted - %s' % self.show.e_title.lower(),
+            template__subject="test template {% url 'gbehome' %}"
+        )
+        url = reverse(self.view_name,
+                      args=[self.context.act.pk],
+                      urlconf='gbe.urls')
+        login_as(self.privileged_user, self)
+        self.data['accepted'] = '3'
+        response = self.client.post(url, data=self.data, follow=True)
+        self.assertContains(response,
+                            bidder_email_fail_msg)
 
     def test_act_accept_act_link_correct(self):
         EmailTemplateSenderFactory(


### PR DESCRIPTION
The problem in #1206 triggered #1209 which then spawned #1210 for later.

I did the following:
 - made a better working link to home page for the schedule update email.  REMINDER - update the instructions and the template when it’s installed.
- made error handling and a catch of any exceptions that are thrown from the email generation process.  When the user is a privileged person, the problem is shared as a error message in our typical pattern.