### PR TITLE
GBE 1161:  be able to remove email recipients from ad hoc mail

### DIFF
--- a/expo/gbe/email/forms/adhoc_email_form.py
+++ b/expo/gbe/email/forms/adhoc_email_form.py
@@ -2,9 +2,11 @@ from django.forms import (
     CharField,
     EmailField,
     Form,
+    MultipleChoiceField,
     Textarea,
     TextInput,
 )
+from django.forms.widgets import CheckboxSelectMultiple
 from tinymce.widgets import TinyMCE
 from django.utils.html import strip_tags
 
@@ -12,6 +14,9 @@ from django.utils.html import strip_tags
 class AdHocEmailForm(Form):
     required_css_class = 'required'
     error_css_class = 'error'
+    to = MultipleChoiceField(
+        required=True,
+        widget=CheckboxSelectMultiple())
     sender = EmailField(required=True,
                         label="From")
     subject = CharField(widget=TextInput(attrs={'size': '79'}))

--- a/expo/gbe/email/views/mail_to_bidders_view.py
+++ b/expo/gbe/email/views/mail_to_bidders_view.py
@@ -80,7 +80,8 @@ class MailToBiddersView(MailToFilterView):
                 for bid in eval(bid_type).objects.filter(draft_query):
                     bidder = (bid.profile.user_object.email,
                               bid.profile.display_name)
-                    if bid.profile.user_object.is_active and bidder not in to_list:
+                    if bid.profile.user_object.is_active and (
+                            bidder not in to_list):
                         to_list += [bidder]
         return sorted(to_list, key=lambda s: s[1].lower())
 

--- a/expo/gbe/email/views/mail_to_bidders_view.py
+++ b/expo/gbe/email/views/mail_to_bidders_view.py
@@ -17,6 +17,7 @@ from gbe.email.forms import (
 from gbe.email.views import MailToFilterView
 from gbetext import to_list_empty_msg
 from django.db.models import Q
+from operator import itemgetter
 
 
 class MailToBiddersView(MailToFilterView):
@@ -52,7 +53,7 @@ class MailToBiddersView(MailToFilterView):
         self.select_form.fields['bid_type'].choices = self.bid_type_choices
 
     def get_to_list(self):
-        to_list = {}
+        to_list = []
         bid_types = self.select_form.cleaned_data['bid_type']
         query = Q(b_conference__in=self.select_form.cleaned_data['conference'])
 
@@ -71,15 +72,17 @@ class MailToBiddersView(MailToFilterView):
 
         for bid_type in bid_types:
             for bid in eval(bid_type).objects.filter(query):
-                if bid.profile.user_object.is_active:
-                    to_list[bid.profile.user_object.email] = \
-                        bid.profile.display_name
+                bidder = (bid.profile.user_object.email,
+                          bid.profile.display_name)
+                if bid.profile.user_object.is_active and bidder not in to_list:
+                    to_list += [bidder]
             if draft:
                 for bid in eval(bid_type).objects.filter(draft_query):
-                    if bid.profile.user_object.is_active:
-                        to_list[bid.profile.user_object.email] = \
-                            bid.profile.display_name
-        return to_list
+                    bidder = (bid.profile.user_object.email,
+                              bid.profile.display_name)
+                    if bid.profile.user_object.is_active and bidder not in to_list:
+                        to_list += [bidder]
+        return sorted(to_list, key=lambda s: s[1].lower())
 
     def prep_email_form(self, request):
         to_list = self.get_to_list()
@@ -105,7 +108,7 @@ class MailToBiddersView(MailToFilterView):
                 request,
                 self.template,
                 {"selection_form": self.select_form})
-        email_form = self.setup_email_form(request)
+        email_form = self.setup_email_form(request, to_list)
         recipient_info = SecretBidderInfoForm(request.POST,
                                               prefix="email-select")
         recipient_info.fields['bid_type'].choices = self.bid_type_choices
@@ -114,5 +117,5 @@ class MailToBiddersView(MailToFilterView):
             request,
             self.template,
             {"selection_form": self.select_form,
-             "email_forms": [email_form, recipient_info],
-             "to_list": to_list, })
+             "email_form": email_form,
+             "recipient_info": [recipient_info]})

--- a/expo/gbe/email/views/mail_to_person_view.py
+++ b/expo/gbe/email/views/mail_to_person_view.py
@@ -25,19 +25,19 @@ class MailToPersonView(MailView):
         user_profile = get_object_or_404(
             Profile,
             resourceitem_id=kwargs.get('profile_id'))
-        return {user_profile.user_object.email: user_profile.display_name}
+        return [(user_profile.user_object.email, "%s <%s>" % (
+            user_profile.display_name,
+            user_profile.user_object.email))]
 
     @never_cache
     @method_decorator(login_required)
     def get(self, request, *args, **kwargs):
         to_address = self.groundwork(request, args, kwargs)
-        email_form = self.setup_email_form(request)
+        email_form = self.setup_email_form(request, to_address)
         return render(
             request,
             'gbe/email/send_mail.tmpl',
-            {"to_address": to_address,
-             "email_form": email_form}
-             )
+            {"email_form": email_form})
 
     @never_cache
     @method_decorator(login_required)
@@ -52,5 +52,4 @@ class MailToPersonView(MailView):
             return render(
                 request,
                 'gbe/email/send_mail.tmpl',
-                {"to_address": to_address,
-                 "email_form": mail_form})
+                {"email_form": mail_form})

--- a/expo/gbe/email/views/mail_view.py
+++ b/expo/gbe/email/views/mail_view.py
@@ -39,9 +39,10 @@ class MailView(View):
                     'recipients': [email],
                     'subject': mail_form.cleaned_data['subject'],
                     'html_message': mail_form.cleaned_data['html_message'], }]
-                recipient_string = "%s, %s" % (
-                    recipient_string,
-                    email)
+                if len(recipient_string) > 0:
+                    recipient_string = "%s, %s" % (recipient_string, email)
+                else:
+                    recipient_string = email
 
             mail.send_many(email_batch)
             user_message = UserMessage.objects.get_or_create(

--- a/expo/gbe/templates/gbe/email/mail_to_group.tmpl
+++ b/expo/gbe/templates/gbe/email/mail_to_group.tmpl
@@ -1,9 +1,9 @@
 {% extends 'base.tmpl' %}
 
 {% block head %}
- {% for email_form in email_forms %}
+ {% if email_form %}
   {{ email_form.media }}
- {% endfor %}
+ {% endif %}
 {% endblock %}
 
 {% block content %}
@@ -40,35 +40,40 @@
     {% if everyone %}</div>{% endif %}
   </div>
 </div>
-{% if email_forms %}
+{% if email_form %}
+<form action="" method="post" enctype="multipart/form-data"> 
+
 <div class="panel panel-primary">
   <div class="panel-heading">
     <h3 class="panel-title">Send Email</h3>
   </div>
   <div class="panel-body">
+      {% include "form_table_wrapper.tmpl" with forms=recipient_info %}
+      {% if everyone %}<input id="id_everyone" name="everyone" type="hidden" value="Everyone" />{% endif %}
       <div class="panel-group">
         <div class="panel panel-default">
           <div class="panel-heading">
             <h4 class="panel-title">
-              <a data-toggle="collapse" href="#to_list">Recipients ({{to_list|length}})...</a>
+              <a data-toggle="collapse" href="#to_list">Recipients ({{email_form.to|length}})...</a>
             </h4>
           </div>
           <div id="to_list" class="panel-collapse collapse">
             <div class="panel-body">
-              {% for email, display_name in to_list.items %}
-                {{display_name}} &lt;{{email}}&gt;;
-              {% endfor %}</div>
+              {% include "gbe/email/filter_checkbox_horizontal.tmpl" with field=email_form.to %}
+            </div>
           </div>
         </div>
       </div>
-
-    <form action="" method="post" enctype="multipart/form-data"> 
-      {% include "form_table_wrapper.tmpl" with forms=email_forms %}
-      {% if everyone %}<input id="id_everyone" name="everyone" type="hidden" value="Everyone" />{% endif %}
-
+     {% if email_form.sender in email_form.visible_fields %}
+       {% include "form_field.tmpl" with field=email_form.sender %}
+     {% else %}
+      {{ email_form.sender }}
+     {% endif %}
+     {% include "form_field.tmpl" with field=email_form.subject %}
+     {% include "form_field.tmpl" with field=email_form.html_message %}
       <input type="submit" class="email-submit" name="send" value="Send">
-    </form>
   </div>
 </div>
+</form>
 {% endif %}
 {% endblock %}

--- a/expo/gbe/templates/gbe/email/send_mail.tmpl
+++ b/expo/gbe/templates/gbe/email/send_mail.tmpl
@@ -15,18 +15,6 @@
     <h3 class="panel-title">Send Email</h3>
   </div>
   <div class="panel-body">
-      <div class="panel-group">
-        <div class="panel panel-default">
-          <div class="panel-heading">
-            <h4 class="panel-title">
-              {% for email, name in to_address.items%}
-              Recipient: {{name}} &lt;{{email}}&gt;
-              {% endfor %}
-            </h4>
-          </div>
-        </div>
-      </div>
-
     <form action="" method="post" enctype="multipart/form-data"> 
       {% include "form_table.tmpl" with form=email_form %}
       <input type="submit" class="email-submit" name="send" value="Send">

--- a/expo/templates/form_field.tmpl
+++ b/expo/templates/form_field.tmpl
@@ -1,0 +1,52 @@
+  {% load staticfiles %}
+    <div class="form-group">
+	<div class="container">
+	<div class="row">
+	<div class="col-md-2">
+	<label for="{{field.name}}" class="control-label">	      
+            {% if field.errors %}
+              <font color="red">!</font>&nbsp;&nbsp;
+	    {% elif field.css_classes == 'required' or field.name in submit_fields %}
+              <font color="red">*</font>
+            {% endif %} 
+            {% if field.errors %}
+                <font color="red">
+            {% endif %}
+            {% if field.name in draft_fields %}
+	        <b>{{ field.label_tag }}</b>
+	    {% else %}
+	        {{ field.label_tag }}
+	    {% endif %}
+
+            {% if field.errors %}
+                </font>
+            {% endif %} 
+
+            {% if field.help_text %}
+                <span class="dropt" title="Help">
+                <img src= "{% static "img/question.png" %}" alt="?"/>
+                  <span style="width:200px;float:right;text-align:left;">
+                  {{ field.help_text }}
+                  </span>
+                </span>
+            {% endif %}
+	</label>
+	</div>
+	<div class="col-md-4{% if field.field.choices|length > 7 %} long_choice{%endif%}">
+            {{ field }}
+	</div>
+	</div>
+	</div>
+
+      {% if field.errors %}
+	<div class="container">
+        <div class="row">
+	  <div class="col-md-2">&nbsp;</div>
+	  <div class="col-md-4">
+ 	    <label for="field.name">	      
+              <font color="red">{{ field.errors }}</font>
+            </label>
+	  </div>
+	</div>
+	</div>
+      {% endif %}

--- a/expo/tests/gbe/email/test_mail_to_bidders.py
+++ b/expo/tests/gbe/email/test_mail_to_bidders.py
@@ -321,6 +321,7 @@ class TestMailToBidder(TestCase):
     def test_send_email_success_status(self):
         login_as(self.privileged_profile, self)
         data = {
+            'to': self.context.teacher.contact.user_object.email,
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -331,14 +332,14 @@ class TestMailToBidder(TestCase):
         }
         response = self.client.post(self.url, data=data, follow=True)
         assert_alert_exists(
-            response, 'success', 'Success', "%s%s (%s), " % (
+            response, 'success', 'Success', "%s%s" % (
                 send_email_success_msg,
-                self.context.teacher.contact.display_name,
                 self.context.teacher.contact.user_object.email))
 
     def test_send_email_success_email_sent(self):
         login_as(self.privileged_profile, self)
         data = {
+            'to': self.context.teacher.contact.user_object.email,
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -359,6 +360,7 @@ class TestMailToBidder(TestCase):
         reduced_profile = self.reduced_login()
         second_bid = ActFactory(submitted=True)
         data = {
+            'to': second_bid.performer.contact.user_object.email,
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -380,6 +382,7 @@ class TestMailToBidder(TestCase):
         reduced_profile = self.reduced_login()
         second_bid = ActFactory()
         data = {
+            'to': second_bid.performer.contact.user_object.email,
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -395,6 +398,29 @@ class TestMailToBidder(TestCase):
             'Select a valid choice. Class is not one of the available choices.'
             )
 
+    def test_send_email_reduced_to_list_no_hack(self):
+        reduced_profile = self.reduced_login()
+        second_bid = ActFactory(submitted=True)
+        random = ProfileFactory()
+        data = {
+            'to': [second_bid.performer.contact.user_object.email,
+                   random.user_object.email],
+            'sender': "sender@admintest.com",
+            'subject': "Subject",
+            'html_message': "<p>Test Message</p>",
+            'email-select-conference': [self.context.conference.pk,
+                                        second_bid.b_conference.pk],
+            'email-select-bid_type': ['Act'],
+            'email-select-state': [0, 1, 2, 3, 4, 5],
+            'send': True
+        }
+        response = self.client.post(self.url, data=data, follow=True)
+        print response
+        self.assertContains(
+            response,
+            'Select a valid choice. %s is not one of the available choices.' % random.user_object.email
+            )
+
     def test_send_email_failure(self):
         login_as(self.privileged_profile, self)
         data = {
@@ -406,11 +432,12 @@ class TestMailToBidder(TestCase):
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
-        self.assertContains(response, "This field is required.")
+        self.assertContains(response, "This field is required.", 2)
 
     def test_send_email_failure_preserve_to_list(self):
         login_as(self.privileged_profile, self)
         data = {
+            'to': self.context.teacher.contact.user_object.email,
             'sender': "sender@admintest.com",
             'html_message': "<p>Test Message</p>",
             'email-select-conference': [self.context.conference.pk],
@@ -419,11 +446,12 @@ class TestMailToBidder(TestCase):
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
+        to_string = '<input checked="checked" id="id_to_0" name="to" ' + \
+            'type="checkbox" value="%s" />%s'
         self.assertContains(
             response,
-            "%s &lt;%s&gt;;" % (
-                self.context.teacher.contact.display_name,
-                self.context.teacher.contact.user_object.email))
+            to_string % (self.context.teacher.contact.user_object.email,
+                         self.context.teacher.contact.display_name))
 
     def test_send_email_failure_preserve_conference_choice(self):
         login_as(self.privileged_profile, self)
@@ -492,6 +520,8 @@ class TestMailToBidder(TestCase):
     def test_send_everyone_success_email_sent(self):
         login_as(self.privileged_profile, self)
         data = {
+            'to': User.objects.exclude(
+                username="limbo").values_list('email', flat=True),
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -527,6 +557,8 @@ class TestMailToBidder(TestCase):
             'secondsuper', 'secondsuper@test.com', "mypassword")
         login_as(self.privileged_profile, self)
         data = {
+            'to': [self.privileged_profile.user_object.email,
+                   second_super.email],
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -535,9 +567,7 @@ class TestMailToBidder(TestCase):
         }
         response = self.client.post(self.url, data=data, follow=True)
         assert_alert_exists(
-            response, 'success', 'Success', "%s%s (%s), %s (%s), " % (
+            response, 'success', 'Success', "%s%s, %s" % (
                 send_email_success_msg,
-                self.privileged_profile.display_name,
                 self.privileged_profile.user_object.email,
-                second_super.username,
                 second_super.email))

--- a/expo/tests/gbe/email/test_mail_to_bidders.py
+++ b/expo/tests/gbe/email/test_mail_to_bidders.py
@@ -415,11 +415,11 @@ class TestMailToBidder(TestCase):
             'send': True
         }
         response = self.client.post(self.url, data=data, follow=True)
-        print response
         self.assertContains(
             response,
-            'Select a valid choice. %s is not one of the available choices.' % random.user_object.email
-            )
+            'Select a valid choice. %s is %s' % (
+                random.user_object.email,
+                'not one of the available choices.'))
 
     def test_send_email_failure(self):
         login_as(self.privileged_profile, self)

--- a/expo/tests/gbe/email/test_mail_to_person.py
+++ b/expo/tests/gbe/email/test_mail_to_person.py
@@ -16,7 +16,7 @@ from gbetext import send_email_success_msg
 from django.contrib.auth.models import User
 
 
-class TestMailToBidder(TestCase):
+class TestMailToPerson(TestCase):
     view_name = 'mail_to_individual'
     priv_list = ['Registrar',
                  'Volunteer Coordinator',
@@ -65,7 +65,7 @@ class TestMailToBidder(TestCase):
         response = self.client.get(self.url, follow=True)
         self.assertContains(
             response,
-            'Recipient: %s &lt;%s&gt;' % (
+            '%s &lt;%s&gt;' % (
                 self.to_profile.display_name,
                 self.to_profile.user_object.email))
 
@@ -86,7 +86,7 @@ class TestMailToBidder(TestCase):
             response = self.client.get(self.url, follow=True)
             self.assertContains(
                 response,
-                'Recipient: %s &lt;%s&gt;' % (
+                '%s &lt;%s&gt;' % (
                     self.to_profile.display_name,
                     self.to_profile.user_object.email))
 
@@ -109,6 +109,7 @@ class TestMailToBidder(TestCase):
     def test_send_email_success_status(self):
         login_as(self.privileged_profile, self)
         data = {
+            'to': self.to_profile.user_object.email,
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -116,14 +117,14 @@ class TestMailToBidder(TestCase):
         }
         response = self.client.post(self.url, data=data, follow=True)
         assert_alert_exists(
-            response, 'success', 'Success', "%s%s (%s), " % (
+            response, 'success', 'Success', "%s%s" % (
                 send_email_success_msg,
-                self.to_profile.display_name,
                 self.to_profile.user_object.email))
 
     def test_send_email_success_email_sent(self):
         login_as(self.privileged_profile, self)
         data = {
+            'to': self.to_profile.user_object.email,
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -140,6 +141,7 @@ class TestMailToBidder(TestCase):
     def test_send_email_reduced_w_fixed_from(self):
         reduced_profile = self.reduced_login()
         data = {
+            'to': self.to_profile.user_object.email,
             'sender': "sender@admintest.com",
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",

--- a/expo/tests/gbe/email/test_mail_to_roles.py
+++ b/expo/tests/gbe/email/test_mail_to_roles.py
@@ -563,6 +563,7 @@ class TestMailToRoles(TestCase):
         volunteer, booking = staffcontext.book_volunteer()
         login_as(self.privileged_profile, self)
         data = {
+            'to': volunteer.user_object.email,
             'sender': self.privileged_profile.user_object.email,
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -574,9 +575,8 @@ class TestMailToRoles(TestCase):
         }
         response = self.client.post(self.url, data=data, follow=True)
         assert_alert_exists(
-            response, 'success', 'Success', "%s%s (%s), " % (
+            response, 'success', 'Success', "%s%s" % (
                 send_email_success_msg,
-                volunteer.display_name,
                 volunteer.user_object.email))
 
     def test_send_email_success_email_sent(self):
@@ -586,6 +586,7 @@ class TestMailToRoles(TestCase):
         showcontext.set_producer(producer=staffcontext.staff_lead)
         login_as(staffcontext.staff_lead, self)
         data = {
+            'to': volunteer.user_object.email,
             'sender': staffcontext.staff_lead.user_object.email,
             'subject': "Subject",
             'html_message': "<p>Test Message</p>",
@@ -611,6 +612,7 @@ class TestMailToRoles(TestCase):
         showcontext.set_producer(producer=staffcontext.staff_lead)
         login_as(self.privileged_profile, self)
         data = {
+            'to': volunteer.user_object.email,
             'sender': "sender@admintest.com",
             'html_message': "<p>Test Message</p>",
             'email-select-conference': [self.context.conference.pk],


### PR DESCRIPTION
for both mail to bidders and mail to roles, the user can now deselect people from the “to” list for the email.  The code still checks the validity of the full list to make sure that nothing got snuck in there.

To make this all readable, I reduced the to list to only names, not emails.