### PR TITLE
GBE 1223: Make sure display name is always clean

### DIFF
--- a/expo/gbe/forms/participant_form.py
+++ b/expo/gbe/forms/participant_form.py
@@ -54,10 +54,10 @@ class ParticipantForm(ModelForm):
         if len(self.cleaned_data['last_name'].strip()) > 0:
             user.last_name = self.cleaned_data['last_name'].strip()
         if self.cleaned_data['display_name']:
-            pass   # if they enter a display name, respect it
+            partform.display_name = self.cleaned_data['display_name'].strip()
         else:
-            partform.display_name = " ".join([self.cleaned_data['first_name'],
-                                              self.cleaned_data['last_name']])
+            partform.display_name = "%s %s" % (user.first_name,
+                                               user.last_name)
         if commit and self.is_valid():
             partform.save()
             partform.user_object.save()

--- a/expo/gbe/forms/participant_form.py
+++ b/expo/gbe/forms/participant_form.py
@@ -13,6 +13,7 @@ from gbe_forms_text import (
 )
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
+import re
 
 
 class ParticipantForm(ModelForm):
@@ -54,10 +55,11 @@ class ParticipantForm(ModelForm):
         if len(self.cleaned_data['last_name'].strip()) > 0:
             user.last_name = self.cleaned_data['last_name'].strip()
         if self.cleaned_data['display_name']:
-            partform.display_name = self.cleaned_data['display_name'].strip()
+            display_name = self.cleaned_data['display_name'].strip()
         else:
-            partform.display_name = "%s %s" % (user.first_name,
-                                               user.last_name)
+            display_name = "%s %s" % (user.first_name, user.last_name)
+        partform.display_name = re.sub(' +',' ',display_name).title()
+
         if commit and self.is_valid():
             partform.save()
             partform.user_object.save()

--- a/expo/gbe/forms/participant_form.py
+++ b/expo/gbe/forms/participant_form.py
@@ -58,7 +58,7 @@ class ParticipantForm(ModelForm):
             display_name = self.cleaned_data['display_name'].strip()
         else:
             display_name = "%s %s" % (user.first_name, user.last_name)
-        partform.display_name = re.sub(' +',' ',display_name).title()
+        partform.display_name = re.sub(' +', ' ', display_name).title()
 
         if commit and self.is_valid():
             partform.save()

--- a/expo/gbe/migrations/0023_clean_display_name.py
+++ b/expo/gbe/migrations/0023_clean_display_name.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import re
+from django.db import migrations, models
+
+
+def clean_display_name(apps, schema_editor):
+    Profile = apps.get_model('gbe', 'Profile')
+    for profile in Profile.objects.all():
+        if profile.display_name != profile.display_name.strip():
+            profile.display_name = profile.display_name.strip()
+            profile.save()
+            print "trimmed: " + profile.display_name
+        if profile.display_name != re.sub(' +',' ',profile.display_name):
+            profile.display_name = re.sub(' +',' ',profile.display_name)
+            profile.save()
+            print "removed whitespace: " + profile.display_name
+        if profile.display_name != profile.display_name.title():
+            profile.display_name = profile.display_name.title()
+            profile.save()
+            print "title case: " + profile.display_name
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('gbe', '0022_auto_20180129_0159'),
+    ]
+
+    operations = [
+        migrations.RunPython(clean_display_name),
+    ]

--- a/expo/gbe/migrations/0023_clean_display_name.py
+++ b/expo/gbe/migrations/0023_clean_display_name.py
@@ -11,14 +11,15 @@ def clean_display_name(apps, schema_editor):
             profile.display_name = profile.display_name.strip()
             profile.save()
             print "trimmed: " + profile.display_name
-        if profile.display_name != re.sub(' +',' ',profile.display_name):
-            profile.display_name = re.sub(' +',' ',profile.display_name)
+        if profile.display_name != re.sub(' +', ' ', profile.display_name):
+            profile.display_name = re.sub(' +', ' ', profile.display_name)
             profile.save()
             print "removed whitespace: " + profile.display_name
         if profile.display_name != profile.display_name.title():
             profile.display_name = profile.display_name.title()
             profile.save()
             print "title case: " + profile.display_name
+
 
 class Migration(migrations.Migration):
 

--- a/expo/gbe/views/update_profile_view.py
+++ b/expo/gbe/views/update_profile_view.py
@@ -41,10 +41,6 @@ def UpdateProfileView(request):
                                             prefix='prefs')
         if form.is_valid():
             form.save(commit=True)
-            if form.cleaned_data['display_name'].strip() == '':
-                profile.display_name = "%s %s" % (
-                    request.user.first_name.strip(),
-                    request.user.last_name.strip())
             if profile.purchase_email.strip() == '':
                 profile.purchase_email = request.user.email.strip()
             if prefs_form.is_valid():

--- a/expo/tests/gbe/test_update_profile.py
+++ b/expo/tests/gbe/test_update_profile.py
@@ -101,8 +101,15 @@ class TestUpdateProfile(TestCase):
         data['purchase_email'] = ""
         response = self.post_profile(form=data)
         self.assertTrue(
-            "%s %s" % (data['first_name'],
-                       data['last_name']) in response.content)
+            "%s %s" % (data['first_name'].title(),
+                       data['last_name'].title()) in response.content)
+
+    def test_update_profile_post_cleanup_display_name(self):
+        data = self.get_form()
+        data['display_name'] = " trim me   nocaps"
+        response = self.post_profile(form=data)
+        self.assertTrue(
+            "Trim Me Nocaps" in response.content)
 
     def test_update_profile_post_valid_form(self):
         response = self.post_profile()

--- a/expo/tests/gbe/test_update_profile.py
+++ b/expo/tests/gbe/test_update_profile.py
@@ -86,7 +86,8 @@ class TestUpdateProfile(TestCase):
                 pref.profile.user_object.last_name) in response.content)
 
     def test_update_profile_how_heard(self):
-        pref = ProfilePreferencesFactory(profile__how_heard="[u'Word of mouth']")
+        pref = ProfilePreferencesFactory(
+            profile__how_heard="[u'Word of mouth']")
         url = reverse(self.view_name,
                       urlconf='gbe.urls')
         login_as(pref.profile.user_object, self)


### PR DESCRIPTION
Ended up cleaning up a bunch - 
- display name has no whitespace start/end
- display name has only 1 space between words
- display name is title case (caps on first letter)

This cleans up on submit, and also has a migration to clean up old data, once and for all.

The side effect will be that users always get a nice-looking display name.  If they have chosen some artistic way of representing their name - like all small letters or 3 spaces - too bad, we will forcibly clean them. 