### PR TITLE
GBE-1253: add to the event_settings

### DIFF
--- a/expo/gbe_forms_text.py
+++ b/expo/gbe_forms_text.py
@@ -119,6 +119,14 @@ event_settings = {
         'max_volunteer': 0,
         'open_to_public': True,
     },
+    'rehearsal slot': {
+        'event_type': 'Rehearsal Slot',
+        'second_title': 'Make New Rehearsal Slot',
+        'volunteer_scheduling': False,
+        'roles': [],
+        'max_volunteer': 1,
+        'open_to_public': False,
+    },
 }
 role_map = {
     'Staff Lead': False,

--- a/expo/tests/gbe/scheduling/test_edit_event_view.py
+++ b/expo/tests/gbe/scheduling/test_edit_event_view.py
@@ -23,7 +23,10 @@ from tests.functions.gbe_scheduling_functions import (
     assert_role_choice,
 )
 from expo.settings import DATE_FORMAT
-from tests.contexts import VolunteerContext
+from tests.contexts import (
+    ShowContext,
+    VolunteerContext,
+)
 from gbe.duration import Duration
 from datetime import timedelta
 
@@ -115,6 +118,22 @@ class TestEditEventView(TestCase):
         self.assertContains(
             response,
             'name="new_opp-duration" type="text" value="01:30:00" />')
+
+    def test_authorized_user_can_access_rehearsal(self):
+        self.context = ShowContext()
+        rehearsal, slot = self.context.make_rehearsal()
+        self.url = reverse(
+            self.view_name,
+            args=[self.context.conference.conference_slug,
+                  slot.pk],
+            urlconf='gbe.scheduling.urls')
+
+        login_as(self.privileged_user, self)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Finish")
+        self.assertContains(response, rehearsal.e_title)
+        self.assertNotContains(response, 'Staffing')
 
     def test_vol_opp_present(self):
         vol_context = VolunteerContext()


### PR DESCRIPTION
The blocking error in editing a rehearsal slot came from the event_settings not having an item for a rehearsal slot.