### PR TITLE
GBE-1254: Add a class for the act header div

### DIFF
--- a/expo/gbe/static/styles/base.css
+++ b/expo/gbe/static/styles/base.css
@@ -880,6 +880,14 @@ tr > th.rotate-review > div {
     rotate(270deg);
   width: 10px;
 }
+tr > th.rotate-review > div.act-header {
+  transform: 
+    /* Magic Numbers */
+    translate(0px, 2px)
+    /* 45 is really 360 - 45 */
+    rotate(270deg);
+  width: 10px;
+}
 th.rotate > div > span {
 }
 th.rotate-review > div > span > a {

--- a/expo/gbe/templates/gbe/act_bid_review_list.tmpl
+++ b/expo/gbe/templates/gbe/act_bid_review_list.tmpl
@@ -40,11 +40,11 @@
         <th class="bid-table">{{ header_item }}</th>
       {% endfor %}
       {% for category in categories %}
-	<th class="bid-table rotate-review"><div><span>
+	<th class="bid-table rotate-review"><div class="act-header"><span>
 	{{ category.category }}
 	</span></div></th>{% endfor %}
-        <th class="bid-table rotate-review"><div><span>Average</span></div></th>
-        <th class="bid-table rotate-review"><div><span>Action</span></div></th>
+        <th class="bid-table rotate-review"><div class="act-header"><span>Average</span></div></th>
+        <th class="bid-table rotate-review"><div class="act-header"><span>Action</span></div></th>
       </tr>
     </thead>
     <tfoot>


### PR DESCRIPTION
The act review header (not the footer) is the only place where the existing transform/offset is a bad thing.  Since the other 3 work fine (in class evals, and in the footer), I made a special override for the div for the header for rotated header names.

That seems to work visually.
No changed pepdiff
#1254 