### PR TITLE
GBE-1251:  Make Duration a Float of Hours in Event Managment forms

### DIFF
--- a/expo/gbe/scheduling/forms/schedule_basic_form.py
+++ b/expo/gbe/scheduling/forms/schedule_basic_form.py
@@ -9,9 +9,7 @@ from gbe.models import (
     Event,
     Room
 )
-from gbe.expoformfields import (
-    DurationFormField,
-)
+from gbe.duration import Duration
 from gbe.functions import get_current_conference
 from datetime import time
 from expo.settings import TIME_FORMAT
@@ -50,8 +48,15 @@ class ScheduleBasicForm(ModelForm):
     def __init__(self, *args, **kwargs):
         if 'instance' in kwargs:
             conference = kwargs['instance'].e_conference
+            if 'initial' in kwargs and 'duration' not in kwargs['initial']:
+                kwargs['initial']['duration'] = float(
+                    kwargs['instance'].duration.total_minutes())/60
         else:
             conference = kwargs.pop('conference')
         super(ScheduleBasicForm, self).__init__(*args, **kwargs)
         self.fields['day'] = ModelChoiceField(
             queryset=conference.conferenceday_set.all())
+
+    def clean_duration(self):
+        data = Duration(minutes=self.cleaned_data['duration']*60)
+        return data

--- a/expo/gbe/scheduling/forms/schedule_basic_form.py
+++ b/expo/gbe/scheduling/forms/schedule_basic_form.py
@@ -1,5 +1,6 @@
 from django.forms import (
     ChoiceField,
+    FloatField,
     ModelForm,
     IntegerField,
     ModelChoiceField,
@@ -32,7 +33,9 @@ class ScheduleBasicForm(ModelForm):
     location = ModelChoiceField(
         queryset=Room.objects.all().order_by('name'))
     max_volunteer = IntegerField(required=True)
-
+    duration = FloatField(min_value=0.5,
+                          max_value=12,
+                          required=True)
     class Meta:
         model = Event
         fields = ['e_title',

--- a/expo/gbe/scheduling/forms/schedule_basic_form.py
+++ b/expo/gbe/scheduling/forms/schedule_basic_form.py
@@ -34,6 +34,7 @@ class ScheduleBasicForm(ModelForm):
     duration = FloatField(min_value=0.5,
                           max_value=12,
                           required=True)
+
     class Meta:
         model = Event
         fields = ['e_title',

--- a/expo/gbe/scheduling/views/edit_event_view.py
+++ b/expo/gbe/scheduling/views/edit_event_view.py
@@ -122,7 +122,6 @@ class EditEventView(ManageVolWizardView):
                           ('Volunteer Coordinator',), require=False):
             volunteer_initial_info = initial_form_info.copy()
             volunteer_initial_info.pop('occurrence_id')
-            volunteer_initial_info['duration'] = self.item.duration
             context.update(self.get_manage_opportunity_forms(
                 volunteer_initial_info,
                 self.manage_vol_url,

--- a/expo/gbe/scheduling/views/edit_show_view.py
+++ b/expo/gbe/scheduling/views/edit_show_view.py
@@ -76,7 +76,6 @@ class EditShowView(EditEventView):
                     day = get_conference_day(
                         conference=rehearsal.e_conference,
                         date=date)
-                    duration = float(rehearsal.duration.total_minutes())/60
                     location = rehearsal_slot.location
                     if location:
                         room = location.room
@@ -93,7 +92,6 @@ class EditShowView(EditEventView):
                                      'max_volunteer': num_volunteers,
                                      'day': day,
                                      'time': time,
-                                     'duration': duration,
                                      'location': room,
                                      },
                             )
@@ -124,7 +122,7 @@ class EditShowView(EditEventView):
                         self).make_context(request, errorcontext=errorcontext)
         initial_rehearsal_info = {
                 'type':  "Rehearsal Slot",
-                'duration': 1,
+                'duration': 1.0,
                 'max_volunteer': 10,
                 'day': get_conference_day(
                     conference=self.conference,

--- a/expo/gbe/scheduling/views/edit_show_view.py
+++ b/expo/gbe/scheduling/views/edit_show_view.py
@@ -76,6 +76,7 @@ class EditShowView(EditEventView):
                     day = get_conference_day(
                         conference=rehearsal.e_conference,
                         date=date)
+                    duration = float(rehearsal.duration.total_minutes())/60
                     location = rehearsal_slot.location
                     if location:
                         room = location.room
@@ -92,6 +93,7 @@ class EditShowView(EditEventView):
                                      'max_volunteer': num_volunteers,
                                      'day': day,
                                      'time': time,
+                                     'duration': duration,
                                      'location': room,
                                      },
                             )

--- a/expo/gbe/scheduling/views/manage_vol_wizard_view.py
+++ b/expo/gbe/scheduling/views/manage_vol_wizard_view.py
@@ -127,6 +127,7 @@ class ManageVolWizardView(View):
                     day = get_conference_day(
                         conference=vol_event.e_conference,
                         date=date)
+                    duration = float(vol_event.duration.total_minutes())/60
                     location = vol_occurence.location
                     if location:
                         room = location.room
@@ -141,6 +142,7 @@ class ManageVolWizardView(View):
                                      'max_volunteer': num_volunteers,
                                      'day': day,
                                      'time': time,
+                                     'duration': duration,
                                      'location': room,
                                      'type': "Volunteer"
                                      },

--- a/expo/gbe/scheduling/views/manage_vol_wizard_view.py
+++ b/expo/gbe/scheduling/views/manage_vol_wizard_view.py
@@ -127,7 +127,6 @@ class ManageVolWizardView(View):
                     day = get_conference_day(
                         conference=vol_event.e_conference,
                         date=date)
-                    duration = float(vol_event.duration.total_minutes())/60
                     location = vol_occurence.location
                     if location:
                         room = location.room
@@ -142,7 +141,6 @@ class ManageVolWizardView(View):
                                      'max_volunteer': num_volunteers,
                                      'day': day,
                                      'time': time,
-                                     'duration': duration,
                                      'location': room,
                                      'type': "Volunteer"
                                      },

--- a/expo/tests/gbe/scheduling/test_edit_event_view.py
+++ b/expo/tests/gbe/scheduling/test_edit_event_view.py
@@ -114,7 +114,7 @@ class TestEditEventView(TestCase):
             'name="new_opp-max_volunteer" type="number" value="7" />')
         self.assertContains(
             response,
-            'name="new_opp-duration" type="text" value="01:30:00" />')
+            'name="new_opp-duration" step="any" type="number" value="1.5" />')
 
     def test_vol_opp_present(self):
         vol_context = VolunteerContext()
@@ -150,7 +150,7 @@ class TestEditEventView(TestCase):
             'name="max_volunteer" type="number" value="2" />')
         self.assertContains(
             response,
-            'name="duration" type="text" value="01:00:00" />')
+            'name="duration" step="any" type="number" value="1.0" />')
 
     def test_bad_conference(self):
         login_as(self.privileged_user, self)

--- a/expo/tests/gbe/scheduling/test_edit_show_view.py
+++ b/expo/tests/gbe/scheduling/test_edit_show_view.py
@@ -44,7 +44,7 @@ class TestEditShowWizard(TestCase):
             'new_slot-e_title': 'New Rehearsal Slot',
             'new_slot-type': "Rehearsal Slot",
             'new_slot-max_volunteer': '1',
-            'new_slot-duration': '1:00:00',
+            'new_slot-duration': '1.0',
             'new_slot-day': self.context.days[0].pk,
             'new_slot-time': '10:00:00',
             'new_slot-location': self.room.pk}
@@ -55,7 +55,7 @@ class TestEditShowWizard(TestCase):
             'e_title': 'Copied Rehearsal Slot',
             'type': 'Rehearsal Slot',
             'max_volunteer': '1',
-            'duration': '1:00:00',
+            'duration': '1.0',
             'day': self.context.days[0].pk,
             'time': '10:00:00',
             'location': self.room.pk}

--- a/expo/tests/gbe/scheduling/test_manage_volunteer_wizard_view.py
+++ b/expo/tests/gbe/scheduling/test_manage_volunteer_wizard_view.py
@@ -50,7 +50,7 @@ class TestManageVolunteerWizard(TestCase):
             'new_opp-volunteer_type': self.avail_interest.pk,
             'new_opp-type': "Volunteer",
             'new_opp-max_volunteer': '1',
-            'new_opp-duration': '1:00:00',
+            'new_opp-duration': '1.0',
             'new_opp-day': self.context.window.day.pk,
             'new_opp-time': '10:00:00',
             'new_opp-location': self.room.pk}
@@ -62,7 +62,7 @@ class TestManageVolunteerWizard(TestCase):
             'volunteer_type': self.avail_interest.pk,
             'type': 'Volunteer',
             'max_volunteer': '1',
-            'duration': '1:00:00',
+            'duration': '1.0',
             'day': self.context.window.day.pk,
             'time': '10:00:00',
             'location': self.room.pk}


### PR DESCRIPTION
Now that forms are all one unified GUI it's a bunch easier to splice in some consistency.
This doesn't go all the way to the model level, it just covers the issue within the volunteer/rehearsal slot forms, but since it operates at the form level, I could do it w/out screwing around in the views.

pepdiff and regressive tests pass.  

Didn't add any new test as the coverage should be covered by existing tests.
#1251 